### PR TITLE
Improve performance and code readability

### DIFF
--- a/WeCantSpell.Hunspell.sln
+++ b/WeCantSpell.Hunspell.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7DB151C3-9662-414F-84EF-7C6BD40C8AC6}"
 EndProject
@@ -24,6 +24,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeCantSpell.Hunspell.Performance.TestHarness", "test\WeCantSpell.Hunspell.Performance.TestHarness\WeCantSpell.Hunspell.Performance.TestHarness.csproj", "{0002E7C7-3EF1-4AD9-A8E6-31C93DF165DE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeCantSpell.Hunspell.Performance.Comparison", "test\WeCantSpell.Hunspell.Performance.Comparison\WeCantSpell.Hunspell.Performance.Comparison.csproj", "{0EBAB771-D55F-430A-ADBD-EA81D97C94AD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WeCantSpell.Hunspell.Performance.TestHarness.Core", "test\WeCantSpell.Hunspell.Performance.TestHarness.Core\WeCantSpell.Hunspell.Performance.TestHarness.Core.csproj", "{FFFDC9E9-D4AB-4D10-8D1B-0561FB98CAC1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,10 @@ Global
 		{0EBAB771-D55F-430A-ADBD-EA81D97C94AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0EBAB771-D55F-430A-ADBD-EA81D97C94AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0EBAB771-D55F-430A-ADBD-EA81D97C94AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFFDC9E9-D4AB-4D10-8D1B-0561FB98CAC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFFDC9E9-D4AB-4D10-8D1B-0561FB98CAC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFFDC9E9-D4AB-4D10-8D1B-0561FB98CAC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFFDC9E9-D4AB-4D10-8D1B-0561FB98CAC1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -61,6 +67,7 @@ Global
 		{0D9B92F4-F669-427A-95FB-14FC6A555973} = {97D2DB91-AE3A-44AE-9FA3-43557AA8F5FD}
 		{0002E7C7-3EF1-4AD9-A8E6-31C93DF165DE} = {97D2DB91-AE3A-44AE-9FA3-43557AA8F5FD}
 		{0EBAB771-D55F-430A-ADBD-EA81D97C94AD} = {97D2DB91-AE3A-44AE-9FA3-43557AA8F5FD}
+		{FFFDC9E9-D4AB-4D10-8D1B-0561FB98CAC1} = {97D2DB91-AE3A-44AE-9FA3-43557AA8F5FD}
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true

--- a/src/WeCantSpell.Hunspell/AffixConfig.Builder.cs
+++ b/src/WeCantSpell.Hunspell/AffixConfig.Builder.cs
@@ -492,6 +492,12 @@ namespace WeCantSpell.Hunspell
 #if !NO_INLINE
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
+            internal string Dedup(StringSlice value) =>
+                StringDeduper.GetEqualOrAdd(value.ToString());
+
+#if !NO_INLINE
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
             public string Dedup(string value)
             {
 #if DEBUG
@@ -509,7 +515,7 @@ namespace WeCantSpell.Hunspell
                 {
                     for (var i = 0; i < values.Length; i++)
                     {
-                        ref var value = ref values[i];
+                        ref string value = ref values[i];
                         if (value != null)
                         {
                             value = StringDeduper.GetEqualOrAdd(value);
@@ -518,6 +524,22 @@ namespace WeCantSpell.Hunspell
                 }
 
                 return values;
+            }
+
+            internal string[] DedupIntoArray(List<StringSlice> values)
+            {
+                if (values == null || values.Count == 0)
+                {
+                    return ArrayEx<string>.Empty;
+                }
+
+                var result = new string[values.Count];
+                for(var i = 0; i < result.Length; i++)
+                {
+                    result[i] = StringDeduper.GetEqualOrAdd(values[i].ToString());
+                }
+
+                return result;
             }
 
             public MorphSet Dedup(MorphSet value) =>

--- a/src/WeCantSpell.Hunspell/CompoundRule.cs
+++ b/src/WeCantSpell.Hunspell/CompoundRule.cs
@@ -24,5 +24,18 @@ namespace WeCantSpell.Hunspell
             var value = this[index];
             return value == '*' || value == '?';
         }
+
+        internal bool ContainsRuleFlagForEntry(WordEntryDetail details)
+        {
+            foreach (var flag in items)
+            {
+                if (!flag.IsWildcard && details.ContainsFlag(flag))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/WeCantSpell.Hunspell/FlagValue.cs
+++ b/src/WeCantSpell.Hunspell/FlagValue.cs
@@ -326,6 +326,14 @@ namespace WeCantSpell.Hunspell
             get => value == ZeroValue;
         }
 
+        internal bool IsWildcard
+        {
+#if !NO_INLINE
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            get => value == '*' || value == '?';
+        }
+
 #if !NO_INLINE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif

--- a/src/WeCantSpell.Hunspell/Infrastructure/ArrayComparer.cs
+++ b/src/WeCantSpell.Hunspell/Infrastructure/ArrayComparer.cs
@@ -18,11 +18,7 @@ namespace WeCantSpell.Hunspell.Infrastructure
             {
                 return true;
             }
-            if (x == null)
-            {
-                return y == null;
-            }
-            if (y == null || x.Length != y.Length)
+            if (x == null || y == null || x.Length != y.Length)
             {
                 return false;
             }

--- a/src/WeCantSpell.Hunspell/Infrastructure/ArrayWrapper.cs
+++ b/src/WeCantSpell.Hunspell/Infrastructure/ArrayWrapper.cs
@@ -100,20 +100,18 @@ namespace WeCantSpell.Hunspell.Infrastructure
 
         private ArrayComparer<TValue> ArrayComparer { get; }
 
-        public bool Equals(TCollection x, TCollection y)
-        {
-            if (ReferenceEquals(x, y))
-            {
-                return true;
-            }
-            if (x == null || y == null)
-            {
-                return false;
-            }
+        public bool Equals(TCollection x, TCollection y) =>
+            ReferenceEquals(x, y)
+            ||
+            (
+                x != null
+                && y != null
+                && ArrayComparer.Equals(x.items, y.items)
+            );
 
-            return ArrayComparer.Equals(x.items, y.items);
-        }
-
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public int GetHashCode(TCollection obj) => ArrayComparer.GetHashCode(obj.items);
     }
 }

--- a/src/WeCantSpell.Hunspell/Infrastructure/EncodingEx.cs
+++ b/src/WeCantSpell.Hunspell/Infrastructure/EncodingEx.cs
@@ -7,31 +7,29 @@ namespace WeCantSpell.Hunspell.Infrastructure
     {
         public static readonly Encoding DefaultReadEncoding = Encoding.UTF8;
 
-        public static Encoding GetEncodingByName(string encodingName)
+        public static Encoding GetEncodingByName(string encodingName) =>
+            GetEncodingByName(new StringSlice(encodingName));
+
+        public static Encoding GetEncodingByName(StringSlice encodingName)
         {
-#if DEBUG
-            if (encodingName == null)
-            {
-                throw new ArgumentNullException(nameof(encodingName));
-            }
-#endif
-            if (string.IsNullOrEmpty(encodingName))
+            if (encodingName.IsEmpty)
             {
                 return null;
             }
 
-            if ("UTF-8".Equals(encodingName, StringComparison.OrdinalIgnoreCase) || "UTF8".Equals(encodingName, StringComparison.OrdinalIgnoreCase))
+            if (encodingName.Equals("UTF-8", StringComparison.OrdinalIgnoreCase) || encodingName.Equals("UTF8", StringComparison.OrdinalIgnoreCase))
             {
                 return Encoding.UTF8;
             }
 
+            var encodingNameString = encodingName.ToString();
             try
             {
-                return Encoding.GetEncoding(encodingName);
+                return Encoding.GetEncoding(encodingNameString);
             }
             catch (ArgumentException)
             {
-                return GetEncodingByAlternateNames(encodingName);
+                return GetEncodingByAlternateNames(encodingNameString);
             }
         }
 
@@ -40,7 +38,7 @@ namespace WeCantSpell.Hunspell.Infrastructure
             var spaceIndex = encodingName.IndexOf(' ');
             if (spaceIndex > 0)
             {
-                return GetEncodingByName(encodingName.Substring(0, spaceIndex));
+                return GetEncodingByName(encodingName.Subslice(0, spaceIndex));
             }
 
             if (encodingName.Length >= 4 && encodingName.StartsWith("ISO") && encodingName[3] != '-')

--- a/src/WeCantSpell.Hunspell/Infrastructure/IncrementalWordList.cs
+++ b/src/WeCantSpell.Hunspell/Infrastructure/IncrementalWordList.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+
+#if !NO_INLINE
+using System.Runtime.CompilerServices;
+#endif
+
+
+namespace WeCantSpell.Hunspell.Infrastructure
+{
+    internal class IncrementalWordList
+    {
+        public IncrementalWordList()
+            : this(new List<WordEntryDetail>(), 0) { }
+
+        public IncrementalWordList(List<WordEntryDetail> words, int wNum)
+        {
+#if DEBUG
+            if (words == null)
+            {
+                throw new ArgumentNullException(nameof(words));
+            }
+            if (WNum < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(wNum));
+            }
+#endif
+            Words = words;
+            WNum = wNum;
+        }
+
+        public List<WordEntryDetail> Words
+        {
+#if !NO_INLINE
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            get;
+        }
+
+        public int WNum
+        {
+#if !NO_INLINE
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            get;
+        }
+
+        public void SetCurrent(WordEntryDetail value)
+        {
+            if (WNum == Words.Count)
+            {
+                Words.Add(value);
+            }
+            else if (WNum < Words.Count)
+            {
+                Words[WNum] = value;
+            }
+            else
+            {
+                AppendForCurrent(value);
+            }
+        }
+
+        private void AppendForCurrent(WordEntryDetail value)
+        {
+            var blanksToInsert = WNum - Words.Count;
+            for (var i = WNum - Words.Count; i > 0; i--)
+            {
+                Words.Add(null);
+            }
+
+            Words.Add(value);
+        }
+
+        public void ClearCurrent()
+        {
+            if (WNum < Words.Count)
+            {
+                Words[WNum] = null;
+            }
+        }
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public bool CheckIfCurrentIsNotNull() =>
+            CheckIfNotNull(WNum);
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public bool CheckIfNextIsNotNull() =>
+            CheckIfNotNull(WNum + 1);
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private bool CheckIfNotNull(int index) =>
+            (index < Words.Count) && Words[index] != null;
+
+        public bool ContainsFlagAt(int wordIndex, FlagValue flag)
+        {
+#if DEBUG
+            if (wordIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(wordIndex));
+            }
+#endif
+
+            if(wordIndex < Words.Count)
+            {
+                var detail = Words[wordIndex];
+                if (detail != null)
+                {
+                    return detail.ContainsFlag(flag);
+                }
+            }
+
+            return false;
+        }
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public IncrementalWordList CreateIncremented() =>
+            new IncrementalWordList(Words, WNum + 1);
+    }
+}

--- a/src/WeCantSpell.Hunspell/Infrastructure/IntEx.cs
+++ b/src/WeCantSpell.Hunspell/Infrastructure/IntEx.cs
@@ -19,7 +19,19 @@ namespace WeCantSpell.Hunspell.Infrastructure
 #if !NO_INLINE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
+        public static bool TryParseInvariant(StringSlice text, out int value) =>
+            int.TryParse(text.ToString(), NumberStyles.Integer, InvariantNumberFormat, out value);
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static int? TryParseInvariant(string text) =>
+            TryParseInvariant(text, out int value) ? (int?)value : null;
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static int? TryParseInvariant(StringSlice text) =>
             TryParseInvariant(text, out int value) ? (int?)value : null;
     }
 }

--- a/src/WeCantSpell.Hunspell/Infrastructure/StringEx.cs
+++ b/src/WeCantSpell.Hunspell/Infrastructure/StringEx.cs
@@ -13,29 +13,6 @@ namespace WeCantSpell.Hunspell.Infrastructure
 #if !NO_INLINE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public static bool IsNullOrWhiteSpace(string value)
-        {
-#if NO_STRINGISNULLORWHITESPACE
-            if (value != null)
-            {
-                for (var i = 0; i < value.Length; i++)
-                {
-                    if (!char.IsWhiteSpace(value[i]))
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-#else
-            return string.IsNullOrWhiteSpace(value);
-#endif
-        }
-
-#if !NO_INLINE
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool StartsWith(this string @this, char character)
         {
 #if DEBUG
@@ -64,7 +41,12 @@ namespace WeCantSpell.Hunspell.Infrastructure
 #if !NO_INLINE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public static string[] SplitOnSpaceOrTab(this string @this)
+        public static bool IsCommentPrefix(char c) => c == '#' || c == '/';
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static string[] SplitOnTabOrSpace(this string @this)
         {
 #if DEBUG
             if (@this == null)
@@ -78,9 +60,9 @@ namespace WeCantSpell.Hunspell.Infrastructure
 #if !NO_INLINE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public static bool IsSpaceOrTab(char c) => c == ' ' || c == '\t';
+        public static bool IsTabOrSpace(char c) => c == ' ' || c == '\t';
 
-        public static int IndexOfSpaceOrTab(string text, int startIndex)
+        public static int IndexOfTabOrSpace(string text, int startIndex)
         {
 #if DEBUG
             if (text == null)
@@ -90,7 +72,7 @@ namespace WeCantSpell.Hunspell.Infrastructure
 #endif
             for (var i = startIndex; i < text.Length; i++)
             {
-                if (IsSpaceOrTab(text[i]))
+                if (IsTabOrSpace(text[i]))
                 {
                     return i;
                 }
@@ -99,7 +81,7 @@ namespace WeCantSpell.Hunspell.Infrastructure
             return -1;
         }
 
-        public static int IndexOfNonSpaceOrTab(string text, int startIndex)
+        public static int IndexOfNonTabOrSpace(string text, int startIndex)
         {
 #if DEBUG
             if (text == null)
@@ -109,7 +91,7 @@ namespace WeCantSpell.Hunspell.Infrastructure
 #endif
             for (var i = startIndex; i < text.Length; i++)
             {
-                if (!IsSpaceOrTab(text[i]))
+                if (!IsTabOrSpace(text[i]))
                 {
                     return i;
                 }
@@ -211,6 +193,32 @@ namespace WeCantSpell.Hunspell.Infrastructure
             }
 #endif
             return length <= 0 || string.CompareOrdinal(a, aOffset, b, bOffset, length) == 0;
+        }
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static bool EqualsOffset(string a, int aOffset, string b, int bOffset, int length, StringComparison comparisonType)
+        {
+#if DEBUG
+            if (a == null)
+            {
+                throw new ArgumentNullException(nameof(a));
+            }
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
+            }
+            if (aOffset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(aOffset));
+            }
+            if (bOffset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bOffset));
+            }
+#endif
+            return length <= 0 || string.Compare(a, aOffset, b, bOffset, length, comparisonType) == 0;
         }
 
 #if !NO_INLINE

--- a/src/WeCantSpell.Hunspell/Infrastructure/StringSliceEx.cs
+++ b/src/WeCantSpell.Hunspell/Infrastructure/StringSliceEx.cs
@@ -21,20 +21,17 @@ namespace WeCantSpell.Hunspell.Infrastructure
         public static StringSlice Subslice(this string text, int startIndex, int length) =>
             new StringSlice(text, startIndex, length);
 
-        public static List<StringSlice> SliceOnTabOrSpace(this string @this)
+        public static List<StringSlice> SliceOnTabOrSpace(this string @this) =>
+            SliceOnTabOrSpace(new StringSlice(@this));
+
+        public static List<StringSlice> SliceOnTabOrSpace(this StringSlice @this)
         {
-#if DEBUG
-            if (@this == null)
-            {
-                throw new ArgumentNullException(nameof(@this));
-            }
-#endif
             var parts = new List<StringSlice>();
 
             int startIndex = 0;
             int splitIndex;
             int partLength;
-            while ((splitIndex = StringEx.IndexOfSpaceOrTab(@this, startIndex)) >= 0)
+            while ((splitIndex = @this.IndexOfSpaceOrTab(startIndex)) >= 0)
             {
                 partLength = splitIndex - startIndex;
                 if (partLength > 0)

--- a/src/WeCantSpell.Hunspell/PatternEntry.cs
+++ b/src/WeCantSpell.Hunspell/PatternEntry.cs
@@ -1,4 +1,6 @@
-﻿namespace WeCantSpell.Hunspell
+﻿using WeCantSpell.Hunspell.Infrastructure;
+
+namespace WeCantSpell.Hunspell
 {
     public sealed class PatternEntry
     {
@@ -20,5 +22,8 @@
         public FlagValue Condition { get; }
 
         public FlagValue Condition2 { get; }
+
+        internal bool Pattern3DoesNotMatch(string word, int offset) =>
+            Pattern3.Length == 0 || !StringEx.EqualsOffset(word, offset, Pattern3, 0, Pattern3.Length);
     }
 }

--- a/src/WeCantSpell.Hunspell/WordEntry.cs
+++ b/src/WeCantSpell.Hunspell/WordEntry.cs
@@ -1,53 +1,105 @@
-﻿#if !NO_INLINE
+﻿using System;
+
+#if !NO_INLINE
 using System.Runtime.CompilerServices;
 #endif
 
 namespace WeCantSpell.Hunspell
 {
-    public sealed class WordEntry
+    public sealed class WordEntry : IEquatable<WordEntry>
     {
+        public static bool operator ==(WordEntry a, WordEntry b) =>
+            ReferenceEquals(a, null) ? ReferenceEquals(b, null) : a.Equals(b);
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static bool operator !=(WordEntry a, WordEntry b) => !(a == b);
+
         public WordEntry(string word, FlagSet flags, MorphSet morphs, WordEntryOptions options)
+            : this(word, new WordEntryDetail(flags, morphs, options)) { }
+
+        public WordEntry(string word, WordEntryDetail detail)
         {
             Word = word ?? string.Empty;
-            Flags = flags ?? FlagSet.Empty;
-            Morphs = morphs ?? MorphSet.Empty;
-            Options = options;
+            Detail = detail ?? WordEntryDetail.Default;
         }
 
         public string Word { get; }
 
-        public FlagSet Flags { get; }
+        public WordEntryDetail Detail { get; }
 
-        public MorphSet Morphs { get; }
+        public FlagSet Flags
+        {
+#if !NO_INLINE
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            get => Detail.Flags;
+        }
 
-        public WordEntryOptions Options { get; }
+        public MorphSet Morphs
+        {
+#if !NO_INLINE
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            get => Detail.Morphs;
+        }
+
+        public WordEntryOptions Options
+        {
+#if !NO_INLINE
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            get => Detail.Options;
+        }
 
         public bool HasFlags
         {
 #if !NO_INLINE
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-            get => Flags.HasItems;
+            get => Detail.HasFlags;
         }
 
 #if !NO_INLINE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public bool ContainsFlag(FlagValue flag) => Flags.Contains(flag);
+        public bool ContainsFlag(FlagValue flag) => Detail.ContainsFlag(flag);
 
 #if !NO_INLINE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public bool ContainsAnyFlags(FlagValue a, FlagValue b) => HasFlags && Flags.ContainsAny(a, b);
+        public bool ContainsAnyFlags(FlagValue a, FlagValue b) => Detail.ContainsAnyFlags(a, b);
 
 #if !NO_INLINE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public bool ContainsAnyFlags(FlagValue a, FlagValue b, FlagValue c) => HasFlags && Flags.ContainsAny(a, b, c);
+        public bool ContainsAnyFlags(FlagValue a, FlagValue b, FlagValue c) => Detail.ContainsAnyFlags(a, b, c);
 
 #if !NO_INLINE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public bool ContainsAnyFlags(FlagValue a, FlagValue b, FlagValue c, FlagValue d) => HasFlags && Flags.ContainsAny(a, b, c, d);
+        public bool ContainsAnyFlags(FlagValue a, FlagValue b, FlagValue c, FlagValue d) => Detail.ContainsAnyFlags(a, b, c, d);
+
+        public bool Equals(WordEntry other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return other.Word == Word
+                && other.Detail.Equals(Detail);
+        }
+
+        public override bool Equals(object obj) =>
+            obj is WordEntry entry && Equals(entry);
+
+        public override int GetHashCode() =>
+            unchecked(Word.GetHashCode() ^ Detail.GetHashCode());
     }
 }

--- a/src/WeCantSpell.Hunspell/WordEntryDetail.cs
+++ b/src/WeCantSpell.Hunspell/WordEntryDetail.cs
@@ -1,0 +1,84 @@
+﻿using System;
+
+#if !NO_INLINE
+using System.Runtime.CompilerServices;
+#endif
+
+namespace WeCantSpell.Hunspell
+{
+    public class WordEntryDetail : IEquatable<WordEntryDetail>
+    {
+        public static bool operator ==(WordEntryDetail a, WordEntryDetail b) =>
+            ReferenceEquals(a, null) ? ReferenceEquals(b, null) : a.Equals(b);
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static bool operator !=(WordEntryDetail a, WordEntryDetail b) => !(a == b);
+
+        public static WordEntryDetail Default { get; } = new WordEntryDetail(FlagSet.Empty, MorphSet.Empty, WordEntryOptions.None);
+
+        public WordEntryDetail(FlagSet flags, MorphSet morphs, WordEntryOptions options)
+        {
+            Flags = flags ?? FlagSet.Empty;
+            Morphs = morphs ?? MorphSet.Empty;
+            Options = options;
+        }
+
+        public FlagSet Flags { get; }
+
+        public MorphSet Morphs { get; }
+
+        public WordEntryOptions Options { get; }
+
+        public bool HasFlags
+        {
+#if !NO_INLINE
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            get => Flags.HasItems;
+        }
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public bool ContainsFlag(FlagValue flag) => Flags.Contains(flag);
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public bool ContainsAnyFlags(FlagValue a, FlagValue b) => HasFlags && Flags.ContainsAny(a, b);
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public bool ContainsAnyFlags(FlagValue a, FlagValue b, FlagValue c) => HasFlags && Flags.ContainsAny(a, b, c);
+
+#if !NO_INLINE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public bool ContainsAnyFlags(FlagValue a, FlagValue b, FlagValue c, FlagValue d) => HasFlags && Flags.ContainsAny(a, b, c, d);
+
+        public bool Equals(WordEntryDetail other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return other.Options.Equals(Options)
+                && other.Flags.Equals(Flags)
+                && other.Morphs.Equals(Morphs);
+        }
+
+        public override bool Equals(object obj) =>
+            obj is WordEntryDetail d && Equals(d);
+
+        public override int GetHashCode() =>
+            unchecked(Flags.GetHashCode() ^ Morphs.GetHashCode() ^ Options.GetHashCode());
+    }
+}

--- a/src/WeCantSpell.Hunspell/WordEntrySet.cs
+++ b/src/WeCantSpell.Hunspell/WordEntrySet.cs
@@ -23,6 +23,17 @@ namespace WeCantSpell.Hunspell
 
         public static WordEntrySet Create(WordEntry entry) => new WordEntrySet(new[] { entry });
 
+        public static WordEntrySet Create(string word, WordEntryDetail[] details)
+        {
+            var entries = new WordEntry[details.Length];
+            for (var i = 0; i < entries.Length; i++)
+            {
+                entries[i] = new WordEntry(word, details[i]);
+            }
+
+            return TakeArray(entries);
+        }
+
         public static WordEntrySet Create(IEnumerable<WordEntry> entries) =>
             entries == null ? Empty : TakeArray(entries.ToArray());
 

--- a/src/WeCantSpell.Hunspell/WordList.Builder.cs
+++ b/src/WeCantSpell.Hunspell/WordList.Builder.cs
@@ -33,7 +33,7 @@ namespace WeCantSpell.Hunspell
             [Obsolete("Use EntryDetailsByRoot")]
             public Dictionary<string, List<WordEntry>> EntriesByRoot;
 
-            public Dictionary<string, List<WordEntryDetail>> EntryDetailsByRoot;
+            private Dictionary<string, List<WordEntryDetail>> EntryDetailsByRoot;
 
             public readonly AffixConfig Affix;
 
@@ -42,6 +42,24 @@ namespace WeCantSpell.Hunspell
             internal readonly Deduper<MorphSet> MorphSetDeduper;
 
             internal readonly Deduper<WordEntryDetail> WordEntryDetailDeduper;
+
+            public void Add(string word, WordEntryDetail detail)
+            {
+                var details = GetOrCreateDetailList(word);
+
+                details.Add(detail);
+            }
+
+            internal List<WordEntryDetail> GetOrCreateDetailList(string word)
+            {
+                if (!EntryDetailsByRoot.TryGetValue(word, out List<WordEntryDetail> details))
+                {
+                    details = new List<WordEntryDetail>(2);
+                    EntryDetailsByRoot.Add(word, details);
+                }
+
+                return details;
+            }
 
             public WordList ToImmutable() =>
                 ToImmutable(destructive: false);
@@ -116,6 +134,11 @@ namespace WeCantSpell.Hunspell
 
             public void InitializeEntriesByRoot(int expectedSize)
             {
+                if (EntryDetailsByRoot != null)
+                {
+                    return;
+                }
+
                 EntryDetailsByRoot = expectedSize <= 0
                     ? new Dictionary<string, List<WordEntryDetail>>()
                     // PERF: because we add more entries than we are told about, we add a bit more to the expected size

--- a/src/WeCantSpell.Hunspell/WordList.QuerySuggest.cs
+++ b/src/WeCantSpell.Hunspell/WordList.QuerySuggest.cs
@@ -2461,9 +2461,8 @@ namespace WeCantSpell.Hunspell
                 return StringBuilderPool.GetStringAndReturn(target);
             }
 
-            private static void StrMove(StringBuilder dest, int destOffset, StringBuilder src, int srcOffset)
+            private static void StrMove(StringBuilder dest, int destIndex, StringBuilder src, int srcOffset)
             {
-                var destIndex = destOffset;
                 for (var srcIndex = srcOffset; srcIndex < src.Length && destIndex < dest.Length; srcIndex++, destIndex++)
                 {
                     dest[destIndex] = src[srcIndex];

--- a/src/WeCantSpell.Hunspell/WordList.cs
+++ b/src/WeCantSpell.Hunspell/WordList.cs
@@ -62,19 +62,14 @@ namespace WeCantSpell.Hunspell
             }
             else
             {
-                wordListBuilder.InitializeEntriesByRoot(0);
+                wordListBuilder.InitializeEntriesByRoot(-1);
             }
 
             var entryDetail = WordEntryDetail.Default;
 
             foreach (var word in words)
             {
-                if (!wordListBuilder.EntryDetailsByRoot.TryGetValue(word, out List<WordEntryDetail> entryDetails) || entryDetails == null)
-                {
-                    wordListBuilder.EntryDetailsByRoot.Add(word, entryDetails = new List<WordEntryDetail>());
-                }
-
-                entryDetails.Add(entryDetail);
+                wordListBuilder.Add(word, entryDetail);
             }
 
             return wordListBuilder.MoveToImmutable();

--- a/src/WeCantSpell.Hunspell/WordListReader.cs
+++ b/src/WeCantSpell.Hunspell/WordListReader.cs
@@ -293,10 +293,8 @@ namespace WeCantSpell.Hunspell
                 {
                     return true;
                 }
-                if(Builder.EntryDetailsByRoot == null)
-                {
-                    Builder.InitializeEntriesByRoot(-1);
-                }
+
+                Builder.InitializeEntriesByRoot(-1);
             }
 
             var parsed = ParsedWordLine.Parse(line);
@@ -350,10 +348,7 @@ namespace WeCantSpell.Hunspell
             {
                 if (IntEx.TryParseInvariant(initLineMatch.Groups[1].Value, out int expectedSize))
                 {
-                    if (Builder.EntryDetailsByRoot == null)
-                    {
-                        Builder.InitializeEntriesByRoot(expectedSize);
-                    }
+                    Builder.InitializeEntriesByRoot(expectedSize);
 
                     return true;
                 }
@@ -411,11 +406,7 @@ namespace WeCantSpell.Hunspell
                 }
             }
 
-            if (!Builder.EntryDetailsByRoot.TryGetValue(word, out List<WordEntryDetail> details))
-            {
-                details = new List<WordEntryDetail>(2);
-                Builder.EntryDetailsByRoot.Add(word, details);
-            }
+            var details = Builder.GetOrCreateDetailList(word);
 
             var upperCaseHomonym = false;
             if (!onlyUpperCase)

--- a/test/WeCantSpell.Hunspell.Performance.TestHarness.Core/Program.cs
+++ b/test/WeCantSpell.Hunspell.Performance.TestHarness.Core/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace WeCantSpell.Hunspell.Performance.TestHarness.Core
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var exeDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            var filePath = Path.Combine(exeDirectory, "files/be-official.dic");
+
+            for(var i = 0; i < 10; i++)
+            {
+                Console.Write($"Loading {Path.GetFileName(filePath)} :");
+
+                var file = WordListReader.ReadFile(filePath);
+
+                Console.WriteLine("Done");
+            }
+        }
+    }
+}

--- a/test/WeCantSpell.Hunspell.Performance.TestHarness.Core/Properties/launchSettings.json
+++ b/test/WeCantSpell.Hunspell.Performance.TestHarness.Core/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "WeCantSpell.Hunspell.Performance.TestHarness.Core": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/test/WeCantSpell.Hunspell.Performance.TestHarness.Core/WeCantSpell.Hunspell.Performance.TestHarness.Core.csproj
+++ b/test/WeCantSpell.Hunspell.Performance.TestHarness.Core/WeCantSpell.Hunspell.Performance.TestHarness.Core.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="WeCantSpell.Hunspell.Performance.TestHarness.Core.v3.ncrunchproject" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WeCantSpell.Hunspell\WeCantSpell.Hunspell.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\samples\*.dic">
+      <Link>files\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\samples\*.aff">
+      <Link>files\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
+</Project>

--- a/test/WeCantSpell.Hunspell.Performance.TestHarness.Core/WeCantSpell.Hunspell.Performance.TestHarness.Core.v3.ncrunchproject
+++ b/test/WeCantSpell.Hunspell.Performance.TestHarness.Core/WeCantSpell.Hunspell.Performance.TestHarness.Core.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/test/WeCantSpell.Hunspell.Performance.TestHarness/App.config
+++ b/test/WeCantSpell.Hunspell.Performance.TestHarness/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/test/WeCantSpell.Hunspell.Performance.TestHarness/WeCantSpell.Hunspell.Performance.TestHarness.csproj
+++ b/test/WeCantSpell.Hunspell.Performance.TestHarness/WeCantSpell.Hunspell.Performance.TestHarness.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WeCantSpell.Hunspell.Performance.TestHarness</RootNamespace>
     <AssemblyName>WeCantSpell.Hunspell.Performance.TestHarness</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -59,7 +60,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\samples\*.*">
+    <None Include="..\..\samples\*.dic">
+      <Link>files\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\samples\*.aff">
       <Link>files\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/WeCantSpell.Hunspell.Tests/HunspellTests.cs
+++ b/test/WeCantSpell.Hunspell.Tests/HunspellTests.cs
@@ -44,13 +44,12 @@ namespace WeCantSpell.Hunspell.Tests
                 var expected = searchWord == dictionaryWord;
                 var dictionaryBuilder = new WordList.Builder();
                 dictionaryBuilder.InitializeEntriesByRoot(1);
-                dictionaryBuilder.EntryDetailsByRoot[dictionaryWord] = new List<WordEntryDetail>
-                {
+                dictionaryBuilder.Add(
+                    dictionaryWord,
                     new WordEntryDetail(
                         FlagSet.Empty,
                         MorphSet.Empty,
-                        WordEntryOptions.None)
-                };
+                        WordEntryOptions.None));
 
                 var dictionary = dictionaryBuilder.ToImmutable();
 

--- a/test/WeCantSpell.Hunspell.Tests/HunspellTests.cs
+++ b/test/WeCantSpell.Hunspell.Tests/HunspellTests.cs
@@ -44,10 +44,9 @@ namespace WeCantSpell.Hunspell.Tests
                 var expected = searchWord == dictionaryWord;
                 var dictionaryBuilder = new WordList.Builder();
                 dictionaryBuilder.InitializeEntriesByRoot(1);
-                dictionaryBuilder.EntriesByRoot[dictionaryWord] = new List<WordEntry>
+                dictionaryBuilder.EntryDetailsByRoot[dictionaryWord] = new List<WordEntryDetail>
                 {
-                    new WordEntry(
-                        dictionaryWord,
+                    new WordEntryDetail(
                         FlagSet.Empty,
                         MorphSet.Empty,
                         WordEntryOptions.None)

--- a/test/WeCantSpell.Hunspell.Tests/WeCantSpell.Hunspell.Tests.csproj
+++ b/test/WeCantSpell.Hunspell.Tests/WeCantSpell.Hunspell.Tests.csproj
@@ -69,7 +69,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\samples\*.*">
+    <None Include="..\..\samples\*.aff">
+      <Link>samples\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\samples\*.dic">
       <Link>samples\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/WeCantSpell.Hunspell.Tests/WordListReaderTests.cs
+++ b/test/WeCantSpell.Hunspell.Tests/WordListReaderTests.cs
@@ -1027,7 +1027,7 @@ namespace WeCantSpell.Hunspell.Tests
             }
 
             [Theory(Skip = "Not performant enough yet")]
-            [MemberData(nameof(can_read_file_without_exception_args))]
+            [MemberData(nameof(large_assortment_of_dic_files))]
             public async Task can_read_file_without_exception(string filePath)
             {
                 var actual = await WordListReader.ReadFileAsync(filePath);
@@ -1038,7 +1038,8 @@ namespace WeCantSpell.Hunspell.Tests
 
         public class ReadFile : WordListReaderTests
         {
-            [Theory, MemberData(nameof(can_read_file_without_exception_args))]
+            [Theory(Skip = "Not performant enough yet")]
+            [MemberData(nameof(large_assortment_of_dic_files))]
             public void can_read_file_without_exception(string filePath)
             {
                 var actual = WordListReader.ReadFile(filePath);
@@ -1047,11 +1048,11 @@ namespace WeCantSpell.Hunspell.Tests
             }
         }
 
-        public static IEnumerable<object[]> can_read_file_without_exception_args =>
+        public static IEnumerable<object[]> large_assortment_of_dic_files =
             Directory.GetFiles("files/", "*.dic")
             .Concat(Directory.GetFiles("samples/", "*.dic"))
-            .Distinct()
             .OrderBy(x => x)
-            .Select(filePath => new object[] { filePath });
+            .Select(filePath => new object[] { filePath })
+            .ToList();
     }
 }


### PR DESCRIPTION
Reduce regex use in affix reader

Remove regex from the dynamic encoding line reader

Clean up code

Assorted performance changes and a new core test harness

Restructuring the word entry

Reduce dictionary use in compound word checks

Simplify memory used for word entry storage and lookup

Cleanup compound check logic

Remove explicit homonym enumerator use

Remove direct enumerator use for word search

Extract word searches to methods

Improved word search performance

Compound check for loop optimization

Improve compound check readability.

Improve code readability

Improve readability of first compound word logic

Simplify compound check conditions

Optimize boolean logic

Remove junk from test