### PR TITLE
Apply bugfixes and test changes from origin

### DIFF
--- a/WeCantSpell.Hunspell.Tests/AffixReaderTests.cs
+++ b/WeCantSpell.Hunspell.Tests/AffixReaderTests.cs
@@ -1686,7 +1686,8 @@ public class AffixReaderTests
 
         public static string[] can_read_file_without_exception_warning_exceptions =
         {
-            "base_utf.aff" // this file has some strange morph lines at the bottom, maybe a bug?
+            "base_utf.aff", // this file has some strange morph lines at the bottom, maybe a bug?
+            "allcaps.aff" // Bug: https://github.com/aarondandy/WeCantSpell.Hunspell/issues/49
         };
 
         [Theory, MemberData(nameof(can_read_file_without_exception_args))]

--- a/WeCantSpell.Hunspell.Tests/HunspellTests.cs
+++ b/WeCantSpell.Hunspell.Tests/HunspellTests.cs
@@ -120,7 +120,7 @@ public class HunspellTests
         /// Removed from tests in origin but I wanted to keep it around:
         /// https://github.com/hunspell/hunspell/commit/8d2f85556e7d6712277547cdeea0e424e80527c4 .
         /// The comment on the commit shows why it may have been removed, but I want this test so
-        /// I know if chanes in behavior ever impact the limit:
+        /// I know if changes in behavior ever impact the limit:
         ///   This is an artificial limit, it would be better not to limit the recognition of this kind of compounding.
         /// </remarks>
         [Fact]

--- a/WeCantSpell.Hunspell.Tests/HunspellTests.cs
+++ b/WeCantSpell.Hunspell.Tests/HunspellTests.cs
@@ -159,6 +159,12 @@ public class HunspellTests
         [InlineData("files/rep.dic", "autos", new[] { "auto's", "auto" })]
         [InlineData("files/ngram_utf_fix.dic", "человеко", new[] { "человек" })]
         [InlineData("files/utf8_nonbmp.dic", "𐏑𐏒𐏒", new[] { "𐏑 𐏒𐏒", "𐏒𐏑", "𐏒𐏒" })]
+        [InlineData("files/ignoresug.dic", "ինչ", new[] { "ինչ" })]
+        [InlineData("files/ignoresug.dic", "ի՞նչ", new[] { "ինչ" })]
+        [InlineData("files/ignoresug.dic", "մնաս", new[] { "մնաս" })]
+        [InlineData("files/ignoresug.dic", "մնա՜ս", new[] { "մնաս" })]
+        [InlineData("files/ignoresug.dic", "որտեղ", new[] { "որտեղ" })]
+        [InlineData("files/ignoresug.dic", "որտե՞ղ", new[] { "որտեղ" })]
         public async Task words_offer_specific_suggestions(string dictionaryFilePath, string word, string[] expectedSuggestions)
         {
             var dictionary = await WordList.CreateFromFilesAsync(dictionaryFilePath);

--- a/WeCantSpell.Hunspell.Tests/HunspellTests.cs
+++ b/WeCantSpell.Hunspell.Tests/HunspellTests.cs
@@ -115,6 +115,24 @@ public class HunspellTests
 
             checkResult.Should().BeFalse();
         }
+
+        /// <remarks>
+        /// Removed from tests in origin but I wanted to keep it around:
+        /// https://github.com/hunspell/hunspell/commit/8d2f85556e7d6712277547cdeea0e424e80527c4 .
+        /// The comment on the commit shows why it may have been removed, but I want this test so
+        /// I know if chanes in behavior ever impact the limit:
+        ///   This is an artificial limit, it would be better not to limit the recognition of this kind of compounding.
+        /// </remarks>
+        [Fact]
+        public async Task can_still_find_10_break_pattern_word_wrong()
+        {
+            var word = "foo-bar-foo-bar-foo-bar-foo-bar-foo-bar-foo";
+            var dictionary = await WordList.CreateFromFilesAsync("files/break.dic");
+
+            var checkResult = dictionary.Check(word);
+
+            checkResult.Should().BeFalse();
+        }
     }
 
     public class Suggest : HunspellTests

--- a/WeCantSpell.Hunspell.Tests/HunspellTests.cs
+++ b/WeCantSpell.Hunspell.Tests/HunspellTests.cs
@@ -92,6 +92,12 @@ public class HunspellTests
                 return;
             }
 
+            if (dictionaryFilePath.EndsWith("allcaps.dic") && word.EndsWith("Afrique", StringComparison.InvariantCultureIgnoreCase))
+            {
+                // Skips test: https://github.com/aarondandy/WeCantSpell.Hunspell/issues/49
+                return;
+            }
+
             var dictionary = await WordList.CreateFromFilesAsync(dictionaryFilePath);
 
             var checkResult = dictionary.Check(word);
@@ -283,6 +289,18 @@ public class HunspellTests
                 {
                     // NOTE: ph2.wrong does not have a corresponding blank suggestion in the file for rootforbiddenroot
                     suggestionLines.Insert(8, string.Empty);
+                }
+
+                if (suggestionFilePath.EndsWith("breakdefault.sug"))
+                {
+                    // No suggestions were added to compensate for new wrong words
+                    suggestionLines.Add(string.Empty);
+                }
+
+                if (suggestionFilePath.EndsWith("checksharps.sug"))
+                {
+                    // No suggestions were added to compensate for new wrong words
+                    suggestionLines.Add(string.Empty);
                 }
 
                 yield return new SuggestionTestSet

--- a/WeCantSpell.Hunspell.Tests/WeCantSpell.Hunspell.Tests.csproj
+++ b/WeCantSpell.Hunspell.Tests/WeCantSpell.Hunspell.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\hunspell-origin\tests\v1cmdline\*.*">
+    <None Include="..\hunspell-origin\tests\*.*">
       <Link>files\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/WeCantSpell.Hunspell.Tests/WeCantSpell.Hunspell.Tests.csproj
+++ b/WeCantSpell.Hunspell.Tests/WeCantSpell.Hunspell.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);IDE1006</NoWarn>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/WeCantSpell.Hunspell.Tests/WordListReaderTests.cs
+++ b/WeCantSpell.Hunspell.Tests/WordListReaderTests.cs
@@ -125,7 +125,7 @@ public class WordListReaderTests
 
             var actual = await WordListReader.ReadFileAsync(filePath);
 
-            actual.RootWords.Should().HaveCount(4);
+            actual.RootWords.Should().HaveCountGreaterThanOrEqualTo(4);
             actual["OpenOffice.org"].Should().HaveCount(1);
             actual["OpenOffice.org"][0].Flags.Should().BeEmpty();
             actual["Openoffice.org"].Should().HaveCount(1);

--- a/WeCantSpell.Hunspell.Tests/WordListReaderTests.cs
+++ b/WeCantSpell.Hunspell.Tests/WordListReaderTests.cs
@@ -705,25 +705,31 @@ public class WordListReaderTests
 
             var actual = await WordListReader.ReadFileAsync(filePath);
 
-
-            actual.RootWords.Should().HaveCount(4);
-            actual.RootWords.Should().BeEquivalentTo(new[] {
+            actual.RootWords.Should().BeEquivalentTo(new[]
+            {
                 "foo",
                 "bar",
                 "bars",
-                "foos" });
+                "foos",
+                "kg",
+                "Kg",
+                "KG",
+                "cm",
+                "Cm"
+            });
             actual["foo"][0].Flags.Should().ContainInOrder(new[] { 'S' });
-            actual["foo"][0].Morphs.Should().BeEquivalentTo(new[] { "[1]" });
+            actual["foo"][0].Morphs.Should().BeEmpty();
             actual["foo"][1].Flags.Should().ContainInOrder(new[] { 'X', 'Y' });
-            actual["foo"][1].Morphs.Should().BeEquivalentTo(new[] { "[2]" });
-            actual["foo"][2].Flags.Should().ContainInOrder(new[] { 'Y' });
-            actual["foo"][2].Morphs.Should().BeEquivalentTo(new[] { "[3]" });
-            actual["foo"][3].Flags.Should().ContainInOrder(new[] { 'S' });
-            actual["foo"][3].Morphs.Should().BeEquivalentTo(new[] { "[4]" });
+            actual["foo"][1].Morphs.Should().BeEmpty();
             actual["bar"][0].Flags.Should().ContainInOrder(new[] { 'S', 'Y' });
-            actual["bar"][0].Morphs.Should().BeEquivalentTo(new[] { "[5]" });
+            actual["bar"][0].Morphs.Should().BeEmpty();
             actual["bars"][0].Flags.Should().ContainInOrder(new[] { 'X' });
             actual["foos"][0].Flags.Should().ContainInOrder(new[] { 'X' });
+            actual["kg"][0].Flags.Should().BeEmpty();
+            actual["Kg"][0].Flags.Should().ContainInOrder(new[] { 'X' });
+            actual["KG"][0].Flags.Should().ContainInOrder(new[] { 'X' });
+            actual["cm"][0].Flags.Should().BeEmpty();
+            actual["Cm"][0].Flags.Should().ContainInOrder(new[] { 'X' });
         }
 
         [Fact]

--- a/WeCantSpell.Hunspell/WordList.Query.cs
+++ b/WeCantSpell.Hunspell/WordList.Query.cs
@@ -1480,8 +1480,7 @@ public partial class WordList
             // to meet the number of characters conditions, then test it
 
             var peEntry = pe.Entry;
-            var appendLength = peEntry.Append.Length;
-            var tmpl = word.Length - appendLength; // length of tmpword
+            var tmpl = word.Length - peEntry.Append.Length; // length of tmpword
 
             if (
                 (tmpl > 0 || (tmpl == 0 && Affix.FullStrip))
@@ -1492,7 +1491,7 @@ public partial class WordList
                 // generate new root word by removing prefix and adding
                 // back any characters that would have been stripped
 
-                var tmpword = StringEx.ConcatString(peEntry.Strip, word, appendLength, word.Length - appendLength);
+                var tmpword = StringEx.ConcatString(peEntry.Strip, word.AsSpan(peEntry.Append.Length));
 
                 // now make sure all of the conditions on characters
                 // are met.  Please see the appendix at the end of
@@ -1910,15 +1909,14 @@ public partial class WordList
             // to meet the number of characters conditions, then test it
 
             var entry = affix.Entry;
-            var appendLength = entry.Append.Length;
-            var tmpl = word.Length - appendLength; // length of tmpword
+            var tmpl = word.Length - entry.Append.Length; // length of tmpword
 
             if (tmpl > 0 || (tmpl == 0 && Affix.FullStrip))
             {
                 // generate new root word by removing prefix and adding
                 // back any characters that would have been stripped
 
-                var tmpword = StringEx.ConcatString(entry.Strip, word, appendLength, word.Length - appendLength);
+                var tmpword = StringEx.ConcatString(entry.Strip, word.AsSpan(entry.Append.Length));
 
                 // now make sure all of the conditions on characters
                 // are met.  Please see the appendix at the end of

--- a/WeCantSpell.Hunspell/WordList.Query.cs
+++ b/WeCantSpell.Hunspell/WordList.Query.cs
@@ -2145,6 +2145,11 @@ public partial class WordList
         /// </remarks>
         protected string CleanWord2(string src, out CapitalizationType capType, out int abbv)
         {
+            if (Affix.IgnoredChars.HasItems)
+            {
+                src = src.WithoutChars(Affix.IgnoredChars);
+            }
+
             // first skip over any leading blanks
             var qIndex = HunspellTextFunctions.CountMatchingFromLeft(src, ' ');
 


### PR DESCRIPTION
This updates the library to match origin as of Oct 2021. One issue was introduced however that will need to be resolved in the future: https://github.com/aarondandy/WeCantSpell.Hunspell/issues/49