### PR TITLE
Fixes porting mistake in MyIsAlpha

### DIFF
--- a/WeCantSpell.Hunspell/Infrastructure/HunspellTextFunctions.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/HunspellTextFunctions.cs
@@ -128,10 +128,15 @@ static class HunspellTextFunctions
         return lastIndex - searchIndex;
     }
 
+    /// <summary>
+    /// This is a character class function used within Hunspell to determine if a character is an ASCII letter.
+    /// </summary>
+    /// <param name="ch">The character value to check.</param>
+    /// <returns><c>true</c> is a given character is an ASCII letter.</returns>
 #if !NO_INLINE
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-    public static bool MyIsAlpha(char ch) => ch < 128 || char.IsLetter(ch);
+    public static bool MyIsAlpha(char ch) => ch >= 128 || char.IsLetter(ch);
 
 #if !NO_INLINE
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This code path is only covered by one test case and no tests have failed because of it, so I think it is very rarely encountered, if at all. The code was incorrectly but this will cause the logic to match what is in origin.