### PR TITLE
Fixes suffix suggestions

### DIFF
--- a/TestHarness/CheckTest.cs
+++ b/TestHarness/CheckTest.cs
@@ -2,7 +2,7 @@
 
 namespace WeCantSpell.Hunspell.TestHarness;
 
-public class CheckTest
+public static class CheckTest
 {
     public static void Run(string dicFilePath, string wordFilePath)
     {

--- a/TestHarness/LoadTest.cs
+++ b/TestHarness/LoadTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace WeCantSpell.Hunspell.TestHarness;
 
-public class LoadTest
+public static class LoadTest
 {
     public static void LoadDictionary(string filePath)
     {

--- a/TestHarness/Program.cs
+++ b/TestHarness/Program.cs
@@ -9,5 +9,6 @@ app.AddCommand("load-all", (string path) => LoadTest.LoadAllDictionaries(path));
 app.AddCommand("check", (string dicFile, string wordFile) => CheckTest.Run(dicFile, wordFile));
 app.AddCommand("suggest", (string dicFile, string wordFile) => SuggestTest.Run(dicFile, wordFile));
 app.AddCommand("suggest-word", (string dicFile, string word) => SuggestWordTest.Run(dicFile, word));
+app.AddCommand("issue88", SimpleIssueScenarios.Issue88);
 
 app.Run();

--- a/TestHarness/Program.cs
+++ b/TestHarness/Program.cs
@@ -10,5 +10,6 @@ app.AddCommand("check", (string dicFile, string wordFile) => CheckTest.Run(dicFi
 app.AddCommand("suggest", (string dicFile, string wordFile) => SuggestTest.Run(dicFile, wordFile));
 app.AddCommand("suggest-word", (string dicFile, string word) => SuggestWordTest.Run(dicFile, word));
 app.AddCommand("issue88", SimpleIssueScenarios.Issue88);
+app.AddCommand("issue91", SimpleIssueScenarios.Issue91);
 
 app.Run();

--- a/TestHarness/Properties/launchSettings.json
+++ b/TestHarness/Properties/launchSettings.json
@@ -27,6 +27,11 @@
       "commandName": "Project",
       "commandLineArgs": "suggest-word --dic-file \"../temp-data/fr-toutesvariantes.dic\" --word Systemes",
       "workingDirectory": "./"
+    },
+    "Issue #86": {
+      "commandName": "Project",
+      "commandLineArgs": "suggest --dic-file \"../temp-data/issue86/en.dic\" --word-file \"../temp-data/issue86/words.txt\"",
+      "workingDirectory": "./"
     }
   }
 }

--- a/TestHarness/Properties/launchSettings.json
+++ b/TestHarness/Properties/launchSettings.json
@@ -32,6 +32,11 @@
       "commandName": "Project",
       "commandLineArgs": "suggest --dic-file \"../temp-data/issue86/en.dic\" --word-file \"../temp-data/issue86/words.txt\"",
       "workingDirectory": "./"
+    },
+    "Issue #88": {
+      "commandName": "Project",
+      "commandLineArgs": "issue88",
+      "workingDirectory": "./"
     }
   }
 }

--- a/TestHarness/Properties/launchSettings.json
+++ b/TestHarness/Properties/launchSettings.json
@@ -37,6 +37,11 @@
       "commandName": "Project",
       "commandLineArgs": "issue88",
       "workingDirectory": "./"
+    },
+    "Issue #91": {
+      "commandName": "Project",
+      "commandLineArgs": "issue91",
+      "workingDirectory": "./"
     }
   }
 }

--- a/TestHarness/SimpleIssueScenarios.cs
+++ b/TestHarness/SimpleIssueScenarios.cs
@@ -1,0 +1,19 @@
+﻿namespace WeCantSpell.Hunspell.TestHarness;
+
+public static class SimpleIssueScenarios
+{
+    public static void Issue88()
+    {
+        Console.WriteLine("Issue88 Reproduction");
+
+        var inputstringList = new List<string> { "Seville", "Deville" };
+        var dictionary = WordList.CreateFromWords(inputstringList);
+
+        for (var i = 0; i < 10; i++)
+        {
+            var query = "Sevill";
+            var suggestions = dictionary.Suggest(query);
+            Console.WriteLine($"Suggestions for {query}: {string.Join(", ", suggestions)}");
+        }
+    }
+}

--- a/TestHarness/SimpleIssueScenarios.cs
+++ b/TestHarness/SimpleIssueScenarios.cs
@@ -4,14 +4,25 @@ public static class SimpleIssueScenarios
 {
     public static void Issue88()
     {
-        Console.WriteLine("Issue88 Reproduction");
-
-        var inputstringList = new List<string> { "Seville", "Deville" };
+        string[] inputstringList = ["Seville", "Deville"];
         var dictionary = WordList.CreateFromWords(inputstringList);
 
         for (var i = 0; i < 10; i++)
         {
-            var query = "Sevill";
+            const string query = "Sevill";
+            var suggestions = dictionary.Suggest(query);
+            Console.WriteLine($"Suggestions for {query}: {string.Join(", ", suggestions)}");
+        }
+    }
+
+    public static void Issue91()
+    {
+        string[] inputstringList = ["A100", "P100", "A100 Truck", "D100 Series"];
+        var dictionary = WordList.CreateFromWords(inputstringList);
+
+        for (var i = 0; i < 10; i++)
+        {
+            const string query = "100";
             var suggestions = dictionary.Suggest(query);
             Console.WriteLine($"Suggestions for {query}: {string.Join(", ", suggestions)}");
         }

--- a/TestHarness/SuggestTest.cs
+++ b/TestHarness/SuggestTest.cs
@@ -34,7 +34,8 @@ public class SuggestTest
 
         foreach (var word in checkWords)
         {
-            _ = wordList.Suggest(word);
+            var suggestions = wordList.Suggest(word);
+            Console.WriteLine($"{word}: {string.Join(", ", suggestions)}");
         }
     }
 }

--- a/TestHarness/SuggestTest.cs
+++ b/TestHarness/SuggestTest.cs
@@ -2,7 +2,7 @@
 
 namespace WeCantSpell.Hunspell.TestHarness;
 
-public class SuggestTest
+public static class SuggestTest
 {
     public static void Run(string dicFilePath, string wordFilePath)
     {

--- a/TestHarness/SuggestWordTest.cs
+++ b/TestHarness/SuggestWordTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace WeCantSpell.Hunspell.TestHarness;
 
-public class SuggestWordTest
+public static class SuggestWordTest
 {
     public static void Run(string dicFilePath, string word)
     {

--- a/WeCantSpell.Hunspell.Tests/Issue86.cs
+++ b/WeCantSpell.Hunspell.Tests/Issue86.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace WeCantSpell.Hunspell.Tests;
+
+public class Issue86  : IAsyncLifetime
+{
+    private WordList _wordList = null!;
+
+    public async Task InitializeAsync()
+    {
+        _wordList = await WordList.CreateFromFilesAsync("files/English (American).dic");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Theory]
+    [InlineData("epooied", "epoxied")]
+    [InlineData("ewelries", "jewelries")]
+    [InlineData("suabbles", "squabbles")]
+    public void suggest_correct_word(string query, string expected)
+    {
+        var suggestions = _wordList.Suggest(query, new QueryOptions()
+        {
+            TimeLimitSuggestStep = TimeSpan.FromSeconds(1),
+            TimeLimitCompoundCheck = TimeSpan.FromSeconds(1),
+            TimeLimitCompoundSuggest = TimeSpan.FromSeconds(1),
+            TimeLimitSuggestGlobal = TimeSpan.FromSeconds(1),
+        });
+        suggestions.Should().Contain(expected);
+    }
+}

--- a/WeCantSpell.Hunspell.Tests/Issue86.cs
+++ b/WeCantSpell.Hunspell.Tests/Issue86.cs
@@ -33,4 +33,22 @@ public class Issue86  : IAsyncLifetime
         });
         suggestions.Should().Contain(expected);
     }
+
+    [Theory]
+    [InlineData("poiseed")]
+    [InlineData("jewelrys")]
+    [InlineData("squabblees")]
+    public void wrong_words_are_wrong(string given)
+    {
+        _wordList.Check(given).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("epoxied")]
+    [InlineData("jewelries")]
+    [InlineData("squabbles")]
+    public void correct_words_are_correct(string given)
+    {
+        _wordList.Check(given).Should().BeTrue();
+    }
 }

--- a/WeCantSpell.Hunspell/AffixEntry.cs
+++ b/WeCantSpell.Hunspell/AffixEntry.cs
@@ -67,7 +67,7 @@ public abstract class AffixEntry
 
     public abstract bool IsWordSubset(ReadOnlySpan<char> word);
 
-    internal bool TestCondition(ReadOnlySpan<char> word) => Conditions.IsStartingMatch(word);
+    internal abstract bool TestCondition(ReadOnlySpan<char> word);
 
     public bool ContainsContClass(FlagValue flag) => ContClass.Contains(flag);
 
@@ -94,6 +94,8 @@ public sealed class PrefixEntry : AffixEntry
     public override bool IsKeySubset(ReadOnlySpan<char> s2) => HunspellTextFunctions.IsSubset(Key, s2);
 
     public override bool IsWordSubset(ReadOnlySpan<char> s2) => HunspellTextFunctions.IsSubset(Key, s2);
+
+    internal override bool TestCondition(ReadOnlySpan<char> word) => Conditions.IsStartingMatch(word);
 }
 
 [DebuggerDisplay("Key = {Key}, Conditions = {Conditions}")]
@@ -134,4 +136,6 @@ public sealed class SuffixEntry : AffixEntry
             return true;
         }
     }
+
+    internal override bool TestCondition(ReadOnlySpan<char> word) => Conditions.IsEndingMatch(word);
 }

--- a/WeCantSpell.Hunspell/AffixEntry.cs
+++ b/WeCantSpell.Hunspell/AffixEntry.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 
 using WeCantSpell.Hunspell.Infrastructure;
 
 namespace WeCantSpell.Hunspell;
 
+[DebuggerDisplay("Key = {Key}, Conditions = {Conditions}")]
 public abstract class AffixEntry
 {
     protected AffixEntry(
@@ -72,6 +74,7 @@ public abstract class AffixEntry
     public bool ContainsAnyContClass(FlagSet flags) => ContClass.ContainsAny(flags);
 }
 
+[DebuggerDisplay("Key = {Key}, Conditions = {Conditions}")]
 public sealed class PrefixEntry : AffixEntry
 {
     public PrefixEntry(
@@ -93,6 +96,7 @@ public sealed class PrefixEntry : AffixEntry
     public override bool IsWordSubset(ReadOnlySpan<char> s2) => HunspellTextFunctions.IsSubset(Key, s2);
 }
 
+[DebuggerDisplay("Key = {Key}, Conditions = {Conditions}")]
 public sealed class SuffixEntry : AffixEntry
 {
     public SuffixEntry(

--- a/WeCantSpell.Hunspell/AffixGroup.cs
+++ b/WeCantSpell.Hunspell/AffixGroup.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 using WeCantSpell.Hunspell.Infrastructure;
 
 namespace WeCantSpell.Hunspell;
 
+[DebuggerDisplay("AFlag = {AFlag}, Entries = {Entries}")]
 public sealed class AffixGroup<TAffixEntry> where TAffixEntry : AffixEntry
 {
     private AffixGroup(FlagValue aFlag, AffixEntryOptions options, ImmutableArray<TAffixEntry> entries)

--- a/WeCantSpell.Hunspell/WordList.QuerySuggest.cs
+++ b/WeCantSpell.Hunspell/WordList.QuerySuggest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -3063,6 +3064,7 @@ public partial class WordList
             slst.Insert(0, word);
         }
 
+        [DebuggerDisplay("Score = {Score}, {Root}")]
         private struct NGramSuggestSearchRoot
         {
             public static int ScorePhoneComparison(NGramSuggestSearchRoot x, NGramSuggestSearchRoot y) => y.ScorePhone.CompareTo(x.ScorePhone);
@@ -3084,6 +3086,7 @@ public partial class WordList
             public int ScorePhone;
         }
 
+        [DebuggerDisplay("Score = {Score}, Guess = {Guess}")]
         private struct NGramGuess
         {
             public static int ScoreComparison(NGramGuess x, NGramGuess y) => y.Score.CompareTo(x.Score);
@@ -3108,6 +3111,7 @@ public partial class WordList
             }
         }
 
+        [DebuggerDisplay("Word = {Word}")]
         private struct GuessWord
         {
             public string? Word;


### PR DESCRIPTION
There was a silly bug with suffix entries where all affixes were performing a prefix condition match. Oops! This should correct that mistake in a few places where `TestCondition` is called on suffix entries so that suffix entries now perform a suffix match instead of a prefix match. This should fix #86 .