### PR TITLE
Removes default struct constructor

### DIFF
--- a/WeCantSpell.Hunspell/WordEntryDetail.cs
+++ b/WeCantSpell.Hunspell/WordEntryDetail.cs
@@ -12,14 +12,7 @@ public readonly struct WordEntryDetail : IEquatable<WordEntryDetail>
 
     public static bool operator !=(WordEntryDetail a, WordEntryDetail b) => !(a == b);
 
-    public static WordEntryDetail Default { get; } = new WordEntryDetail();
-
-    public WordEntryDetail()
-    {
-        Morphs = MorphSet.Empty;
-        Flags = FlagSet.Empty;
-        Options = WordEntryOptions.None;
-    }
+    public static WordEntryDetail Default { get; } = new WordEntryDetail(FlagSet.Empty, MorphSet.Empty, WordEntryOptions.None);
 
     public WordEntryDetail(FlagSet flags, MorphSet morphs, WordEntryOptions options)
     {


### PR DESCRIPTION
This fixes #87 by removing a default struct constructor.

While I think it is technically a breaking change, anybody affected by this is probably doing something really weird so it's good enough to package into a minor release.