### PR TITLE
Uses more strings in place of mutable arrays

### DIFF
--- a/WeCantSpell.Hunspell.Tests/FlagSetTests.cs
+++ b/WeCantSpell.Hunspell.Tests/FlagSetTests.cs
@@ -13,7 +13,7 @@ public class FlagSetTests
 
         var actual = set.Union((FlagValue)'z');
 
-        actual.Should().Equal(new FlagValue[] { (FlagValue)'a', (FlagValue)'z' });
+        actual.Should().Equal([(FlagValue)'a', (FlagValue)'z']);
     }
 
     [Fact]
@@ -23,16 +23,16 @@ public class FlagSetTests
 
         var actual = set.Union((FlagValue)'a');
 
-        actual.Should().Equal(new FlagValue[] { (FlagValue)'a', (FlagValue)'z' });
+        actual.Should().Equal([(FlagValue)'a', (FlagValue)'z']);
     }
 
     [Fact]
     public void can_union_flag_to_middle()
     {
-        var set = FlagSet.Create(new[] { (FlagValue)'a', (FlagValue)'z' });
+        var set = FlagSet.Create([(FlagValue)'a', (FlagValue)'z']);
 
         var actual = set.Union((FlagValue)'x');
 
-        actual.Should().Equal(new FlagValue[] { (FlagValue)'a', (FlagValue)'x', (FlagValue)'z' });
+        actual.Should().Equal([(FlagValue)'a', (FlagValue)'x', (FlagValue)'z']);
     }
 }

--- a/WeCantSpell.Hunspell.Tests/WeCantSpell.Hunspell.Tests.csproj
+++ b/WeCantSpell.Hunspell.Tests/WeCantSpell.Hunspell.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <NoWarn>$(NoWarn);IDE1006</NoWarn>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WeCantSpell.Hunspell/AffixCollection.cs
+++ b/WeCantSpell.Hunspell/AffixCollection.cs
@@ -160,7 +160,7 @@ public abstract class AffixCollection<TAffixEntry> : IEnumerable<AffixGroup<TAff
 
         protected Dictionary<FlagValue, GroupBuilder> _byFlag = [];
         private protected ArrayBuilder<TAffixEntry> _emptyKeys = [];
-        protected FlagSet.Builder _contClassesBuilder = new();
+        protected HashSet<FlagValue> _contClassAccumulator = [];
         protected Dictionary<char, List<TAffixEntry>> _byFirstKeyChar = [];
 
         public GroupBuilder ForGroup(FlagValue aFlag)
@@ -187,7 +187,7 @@ public abstract class AffixCollection<TAffixEntry> : IEnumerable<AffixGroup<TAff
                 }
             }
 
-            target.ContClasses = allowDestructive ? _contClassesBuilder.MoveToFlagSet() : _contClassesBuilder.Create();
+            target.ContClasses = FlagSet.Create(_contClassAccumulator);
             target._affixesWithEmptyKeys = _emptyKeys.MakeOrExtractArray(allowDestructive);
 
 #if HAS_FROZENDICTIONARY
@@ -354,7 +354,10 @@ public abstract class AffixCollection<TAffixEntry> : IEnumerable<AffixGroup<TAff
 
                 Builder.Entries.Add(entry);
 
-                _parent._contClassesBuilder.AddRange(entry.ContClass);
+                if (entry.ContClass.HasItems)
+                {
+                    _parent._contClassAccumulator.UnionWith(entry.ContClass);
+                }
 
                 if (string.IsNullOrEmpty(entry.Key))
                 {

--- a/WeCantSpell.Hunspell/AffixCollection.cs
+++ b/WeCantSpell.Hunspell/AffixCollection.cs
@@ -416,7 +416,7 @@ public abstract class AffixCollection<TAffixEntry> : IEnumerable<AffixGroup<TAff
         public AffixesByFlagsEnumerator(FlagSet flags, Dictionary<FlagValue, AffixGroup<TAffixEntry>> affixesByFlag)
 #endif
         {
-            _flags = flags.GetInternalArray();
+            _flags = flags.GetInternalText();
             _byFlag = affixesByFlag;
             _group = null;
             _flagsIndex = 0;
@@ -430,7 +430,7 @@ public abstract class AffixCollection<TAffixEntry> : IEnumerable<AffixGroup<TAff
         private readonly Dictionary<FlagValue, AffixGroup<TAffixEntry>> _byFlag;
 #endif
 
-        private readonly char[] _flags;
+        private readonly string _flags;
         private AffixGroup<TAffixEntry>? _group;
         private int _flagsIndex;
         private int _groupIndex;
@@ -477,7 +477,7 @@ public abstract class AffixCollection<TAffixEntry> : IEnumerable<AffixGroup<TAff
         public GroupsByFlagsEnumerator(FlagSet flags, Dictionary<FlagValue, AffixGroup<TAffixEntry>> byFlag)
 #endif
         {
-            _flags = flags.GetInternalArray();
+            _flags = flags.GetInternalText();
             _byFlag = byFlag;
             _current = default!;
             _flagsIndex = 0;
@@ -488,7 +488,7 @@ public abstract class AffixCollection<TAffixEntry> : IEnumerable<AffixGroup<TAff
 #else
         private readonly Dictionary<FlagValue, AffixGroup<TAffixEntry>> _byFlag;
 #endif
-        private readonly char[] _flags;
+        private readonly string _flags;
         private AffixGroup<TAffixEntry> _current;
         private int _flagsIndex;
 

--- a/WeCantSpell.Hunspell/CandidateStack.cs
+++ b/WeCantSpell.Hunspell/CandidateStack.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 using WeCantSpell.Hunspell.Infrastructure;
 
@@ -24,9 +25,12 @@ struct CandidateStack
 
     public static void Pop(ref CandidateStack stack)
     {
-        if (stack._rest is { Count: > 0 } rest)
+        if (stack._rest is { Count: > 0 })
         {
-            rest.RemoveAt(rest.Count - 1);
+            pop(stack._rest);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static void pop(List<string> items) => items.RemoveAt(items.Count - 1);
         }
         else
         {

--- a/WeCantSpell.Hunspell/CandidateStack.cs
+++ b/WeCantSpell.Hunspell/CandidateStack.cs
@@ -26,11 +26,16 @@ struct CandidateStack
     {
         if (stack._rest is { Count: > 0 })
         {
-            stack._rest.RemoveLast();
+            pop(stack._rest);
         }
         else
         {
             stack._s0 = null;
+        }
+
+        static void pop(List<string> values)
+        {
+            values.RemoveAt(values.Count - 1);
         }
     }
 

--- a/WeCantSpell.Hunspell/CandidateStack.cs
+++ b/WeCantSpell.Hunspell/CandidateStack.cs
@@ -24,18 +24,13 @@ struct CandidateStack
 
     public static void Pop(ref CandidateStack stack)
     {
-        if (stack._rest is { Count: > 0 })
+        if (stack._rest is { Count: > 0 } rest)
         {
-            pop(stack._rest);
+            rest.RemoveAt(rest.Count - 1);
         }
         else
         {
             stack._s0 = null;
-        }
-
-        static void pop(List<string> values)
-        {
-            values.RemoveAt(values.Count - 1);
         }
     }
 

--- a/WeCantSpell.Hunspell/CharacterCondition.cs
+++ b/WeCantSpell.Hunspell/CharacterCondition.cs
@@ -72,7 +72,7 @@ public readonly struct CharacterCondition : IReadOnlyList<char>, IEquatable<Char
 
             if (_characters is null)
             {
-                ExceptionEx.ThrowInvalidOperation("Condition is not initialized");
+                ExceptionEx.ThrowInvalidOperation("Not initialized");
             }
 
             return _characters![index];
@@ -116,7 +116,7 @@ public readonly struct CharacterCondition : IReadOnlyList<char>, IEquatable<Char
 
     public bool Equals(CharacterCondition other) =>
         other._mode == _mode
-        && other.GetValuesAsText().SequenceEqual(GetValuesAsText());
+        && other.GetValuesAsText().Equals(GetValuesAsText(), StringComparison.Ordinal);
 
     public override bool Equals(object? obj) => obj is CharacterCondition cc && Equals(cc);
 

--- a/WeCantSpell.Hunspell/CharacterCondition.cs
+++ b/WeCantSpell.Hunspell/CharacterCondition.cs
@@ -89,9 +89,8 @@ public readonly struct CharacterCondition : IReadOnlyList<char>, IEquatable<Char
             1 => _characters[0] == c,
             2 => _characters[0] == c || _characters[1] == c,
             3 => _characters[0] == c || _characters[1] == c || _characters[2] == c,
-            _ => _mode is ModeKind.MatchSequence
-                ? _characters.Contains(c)
-                : MemoryEx.SortedLargeSearchSpaceContains(_characters.AsSpan(), c),
+            > 8 when _mode is not ModeKind.MatchSequence => MemoryEx.SortedLargeSearchSpaceContains(_characters.AsSpan(), c),
+            _ => _characters.Contains(c),
         };
 
     public bool MatchesAnySingleCharacter => _mode == ModeKind.RestrictChars && IsEmpty;

--- a/WeCantSpell.Hunspell/CharacterCondition.cs
+++ b/WeCantSpell.Hunspell/CharacterCondition.cs
@@ -87,9 +87,11 @@ public readonly struct CharacterCondition : IReadOnlyList<char>, IEquatable<Char
         {
             0 => false,
             1 => _characters[0] == c,
-            _ => (_mode is ModeKind.MatchSequence)
+            2 => _characters[0] == c || _characters[1] == c,
+            3 => _characters[0] == c || _characters[1] == c || _characters[2] == c,
+            _ => _mode is ModeKind.MatchSequence
                 ? _characters.Contains(c)
-                : MemoryEx.SortedContains(_characters.AsSpan(), c),
+                : MemoryEx.SortedLargeSearchSpaceContains(_characters.AsSpan(), c),
         };
 
     public bool MatchesAnySingleCharacter => _mode == ModeKind.RestrictChars && IsEmpty;

--- a/WeCantSpell.Hunspell/CharacterCondition.cs
+++ b/WeCantSpell.Hunspell/CharacterCondition.cs
@@ -10,43 +10,49 @@ namespace WeCantSpell.Hunspell;
 
 public readonly struct CharacterCondition : IReadOnlyList<char>, IEquatable<CharacterCondition>
 {
-    public static readonly CharacterCondition AllowAny = new([], ModeKind.RestrictChars);
+    public static readonly CharacterCondition AllowAny = new(string.Empty, ModeKind.RestrictChars);
 
     public static bool operator ==(CharacterCondition left, CharacterCondition right) => left.Equals(right);
 
-    public static bool operator !=(CharacterCondition left, CharacterCondition right) => !(left == right);
+    public static bool operator !=(CharacterCondition left, CharacterCondition right) => !left.Equals(right);
 
     public static CharacterCondition CreateCharSet(ReadOnlySpan<char> chars, bool restricted)
     {
-        var builder = ArrayBuilder<char>.Pool.Get(chars.Length);
-
-        foreach (var c in chars)
-        {
-            builder.AddAsSortedSet(c);
-        }
-
-        return new(ArrayBuilder<char>.Pool.ExtractAndReturn(builder), restricted ? ModeKind.RestrictChars : ModeKind.PermitChars);
+        var builder = new StringBuilderSpan(chars);
+        builder.Sort();
+        builder.RemoveAdjacentDuplicates();
+        return new(builder.GetStringAndDispose(), restricted ? ModeKind.RestrictChars : ModeKind.PermitChars);
     }
 
-    public static CharacterCondition CreateSequence(char c) => new([c], ModeKind.MatchSequence);
+    public static CharacterCondition CreateCharSet(string chars, bool restricted)
+    {
+        var charsSpan = chars.AsSpan();
+        return charsSpan.CheckSortedWithoutDuplicates()
+            ? new(chars, restricted ? ModeKind.RestrictChars : ModeKind.PermitChars)
+            : CreateCharSet(charsSpan, restricted);
+    }
 
-    public static CharacterCondition CreateSequence(ReadOnlySpan<char> chars) => new(chars.ToArray(), ModeKind.MatchSequence);
+    public static CharacterCondition CreateSequence(char c) => CreateSequence(c.ToString());
 
-    private CharacterCondition(char[] characters, ModeKind mode)
+    public static CharacterCondition CreateSequence(ReadOnlySpan<char> chars) => CreateSequence(chars.ToString());
+
+    public static CharacterCondition CreateSequence(string chars) => new(chars, ModeKind.MatchSequence);
+
+    private CharacterCondition(string characters, ModeKind mode)
     {
         _characters = characters;
         _mode = mode;
     }
 
-    private readonly char[]? _characters;
+    private readonly string? _characters;
 
     private readonly ModeKind _mode;
 
-    public IReadOnlyList<char> Characters => GetInternalArray();
+    public IReadOnlyList<char> Characters => _characters is not null ? _characters.ToCharArray() : [];
 
     public ModeKind Mode => _mode;
 
-    public int Count => _characters is null ? 0 : _characters.Length;
+    public int Count => _characters is not null ? _characters.Length : 0;
 
     public bool IsEmpty => _characters is not { Length: > 0 };
 
@@ -64,24 +70,27 @@ public readonly struct CharacterCondition : IReadOnlyList<char>, IEquatable<Char
             ExceptionEx.ThrowIfArgumentGreaterThanOrEqual(index, Count, nameof(index));
 #endif
 
+            if (_characters is null)
+            {
+                ExceptionEx.ThrowInvalidOperation("Condition is not initialized");
+            }
+
             return _characters![index];
         }
     }
 
-    public IEnumerator<char> GetEnumerator() => ((IEnumerable<char>)GetInternalArray()).GetEnumerator();
+    public IEnumerator<char> GetEnumerator() => GetValuesAsText().GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    public bool Contains(char c)
-    {
-        return _characters is { Length: > 0 }
-            &&
-            (
-                (_characters.Length <= 8 || _mode == ModeKind.MatchSequence)
-                ? _characters.Contains(c)
-                : Array.BinarySearch(_characters, c) >= 0
-            );
-    }
+    public bool Contains(char c) =>
+        _characters is not null
+        &&
+        (
+            (_mode is ModeKind.MatchSequence || _characters.Length <= 8)
+            ? _characters.Contains(c)
+            : MemoryEx.SortedContains(_characters.AsSpan(), c)
+        );
 
     public bool MatchesAnySingleCharacter => _mode == ModeKind.RestrictChars && IsEmpty;
 
@@ -92,58 +101,52 @@ public readonly struct CharacterCondition : IReadOnlyList<char>, IEquatable<Char
             return ".";
         }
 
-        var stringValue = GetInternalArray().AsSpan().ToString();
+        var stringValue = GetValuesAsText();
 
         return _mode switch
         {
             ModeKind.MatchSequence => stringValue,
             ModeKind.RestrictChars => "[^" + stringValue + "]",
             ModeKind.PermitChars => "[" + stringValue + "]",
-            _ => handleUnsupportedMode(),
+            _ => ThrowUnsupportedMode(_mode),
         };
-
-#if !NO_EXPOSED_NULLANNOTATIONS
-        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
-#endif
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static string handleUnsupportedMode() => throw new NotSupportedException($"Character condition mode not supported");
     }
 
     public override string ToString() => GetEncoded();
 
     public bool Equals(CharacterCondition other) =>
-        _mode == other._mode
-        && GetInternalArray().SequenceEqual(other.GetInternalArray());
+        other._mode == _mode
+        && other.GetValuesAsText().SequenceEqual(GetValuesAsText());
 
     public override bool Equals(object? obj) => obj is CharacterCondition cc && Equals(cc);
 
-    public override int GetHashCode() => HashCode.Combine(StringEx.GetStableOrdinalHashCode(GetInternalArray()), _mode);
+    public override int GetHashCode() => HashCode.Combine(StringEx.GetStableOrdinalHashCode(GetValuesAsText()), _mode);
 
-    internal char[] GetInternalArray() => _characters ?? [];
+    internal string GetValuesAsText() => _characters ?? string.Empty;
 
     internal bool FullyMatchesFromStart(ReadOnlySpan<char> text, out int matchLength)
     {
         matchLength = 1;
 
-        if (text.IsEmpty)
+        if (text.Length > 0)
         {
-            return false;
-        }
+            switch (_mode)
+            {
+                case ModeKind.PermitChars:
+                    return Contains(text[0]);
 
-        switch (_mode)
-        {
-            case ModeKind.PermitChars:
-                return Contains(text[0]);
-            case ModeKind.RestrictChars:
-                return !Contains(text[0]);
-            case ModeKind.MatchSequence:
-                if (HasItems && text.StartsWith(_characters.AsSpan()))
-                {
-                    matchLength = _characters!.Length;
-                    return true;
-                }
+                case ModeKind.RestrictChars:
+                    return !Contains(text[0]);
 
-                break;
+                case ModeKind.MatchSequence:
+                    if (_characters is { Length: > 0 } && text.StartsWith(_characters.AsSpan()))
+                    {
+                        matchLength = _characters.Length;
+                        return true;
+                    }
+
+                    break;
+            }
         }
 
         return false;
@@ -153,25 +156,25 @@ public readonly struct CharacterCondition : IReadOnlyList<char>, IEquatable<Char
     {
         matchLength = 1;
 
-        if (text.IsEmpty)
+        if (text.Length > 0)
         {
-            return false;
-        }
+            switch (_mode)
+            {
+                case ModeKind.PermitChars:
+                    return Contains(text[text.Length - 1]);
 
-        switch (_mode)
-        {
-            case ModeKind.PermitChars:
-                return Contains(text[text.Length - 1]);
-            case ModeKind.RestrictChars:
-                return !Contains(text[text.Length - 1]);
-            case ModeKind.MatchSequence:
-                if (HasItems && text.EndsWith(_characters.AsSpan()))
-                {
-                    matchLength = _characters!.Length;
-                    return true;
-                }
+                case ModeKind.RestrictChars:
+                    return !Contains(text[text.Length - 1]);
 
-                break;
+                case ModeKind.MatchSequence:
+                    if (_characters is { Length: > 0 } && text.EndsWith(_characters.AsSpan()))
+                    {
+                        matchLength = _characters.Length;
+                        return true;
+                    }
+
+                    break;
+            }
         }
 
         return false;
@@ -181,34 +184,39 @@ public readonly struct CharacterCondition : IReadOnlyList<char>, IEquatable<Char
     {
         matchLength = 1;
 
-        if (text.IsEmpty)
+        if (text.Length > 0)
         {
-            return false;
-        }
+            switch (_mode)
+            {
+                // case ModeKind.RestrictChars: return false;
 
-        switch (_mode)
-        {
-            case ModeKind.RestrictChars:
-                return false;
-            case ModeKind.PermitChars:
-                return HasItems && _characters!.Length == 1 && text.StartsWith(_characters[0]);
-            case ModeKind.MatchSequence:
-                if (HasItems && text.Length >= _characters!.Length && text.StartsWith(_characters.AsSpan()))
-                {
-                    matchLength = _characters.Length;
-                    return true;
-                }
+                case ModeKind.PermitChars:
+                    return _characters is { Length: 1 } && _characters[0] == text[0];
 
-                break;
+                case ModeKind.MatchSequence:
+                    if (_characters is { Length: > 0 } && text.Length >= _characters.Length && text.StartsWith(_characters.AsSpan()))
+                    {
+                        matchLength = _characters.Length;
+                        return true;
+                    }
+
+                    break;
+            }
         }
 
         return false;
     }
 
+#if !NO_EXPOSED_NULLANNOTATIONS
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+#endif
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static string ThrowUnsupportedMode(ModeKind mode) => throw new NotSupportedException("Character condition mode " + mode.ToString() + " not supported");
+
     public enum ModeKind : byte
     {
-        PermitChars,
-        RestrictChars,
-        MatchSequence
+        PermitChars = 0,
+        RestrictChars = 1,
+        MatchSequence = 2,
     }
 }

--- a/WeCantSpell.Hunspell/CharacterSet.cs
+++ b/WeCantSpell.Hunspell/CharacterSet.cs
@@ -277,7 +277,7 @@ public readonly struct CharacterSet : IReadOnlyList<char>, IEquatable<CharacterS
 
         public Builder(int capacity)
         {
-            _builder = capacity is >= 0 and <= CollectionsEx.CollectionPreallocationLimit
+            _builder = capacity is >= 0 and <= 128
                 ? new ArrayBuilder<char>(capacity)
                 : new ArrayBuilder<char>();
         }
@@ -305,6 +305,6 @@ public readonly struct CharacterSet : IReadOnlyList<char>, IEquatable<CharacterS
             _builder.AddAsSortedSet(values);
         }
 
-        public CharacterSet Create() => new(_builder.BuildString());
+        public CharacterSet Create() => new(_builder.AsSpan().ToString());
     }
 }

--- a/WeCantSpell.Hunspell/CharacterSet.cs
+++ b/WeCantSpell.Hunspell/CharacterSet.cs
@@ -101,7 +101,7 @@ public readonly struct CharacterSet : IReadOnlyList<char>, IEquatable<CharacterS
 
             if (_values is null)
             {
-                ExceptionEx.ThrowInvalidOperation("Set is not initialized");
+                ExceptionEx.ThrowInvalidOperation("Not initialized");
             }
 
             return _values![index];

--- a/WeCantSpell.Hunspell/CompoundRule.cs
+++ b/WeCantSpell.Hunspell/CompoundRule.cs
@@ -29,16 +29,19 @@ public readonly struct CompoundRule : IReadOnlyList<FlagValue>
 
         static FlagSet prepareNonWildcardValues(FlagValue[] values)
         {
-            var builder = new FlagSet.Builder(values.Length);
+            var builder = new StringBuilderSpan(values.Length);
             foreach (var value in values)
             {
-                if (value.IsNotWildcard)
+                if (value.HasValue && value.IsNotWildcard)
                 {
-                    builder.Add(value);
+                    builder.Append(value);
                 }
             }
 
-            return builder.MoveToFlagSet();
+            builder.Sort();
+            builder.RemoveAdjacentDuplicates();
+
+            return FlagSet.CreateFromPreparedValues(builder.GetStringAndDispose());
         }
     }
 

--- a/WeCantSpell.Hunspell/CompoundRule.cs
+++ b/WeCantSpell.Hunspell/CompoundRule.cs
@@ -29,16 +29,16 @@ public readonly struct CompoundRule : IReadOnlyList<FlagValue>
 
         static FlagSet prepareNonWildcardValues(FlagValue[] values)
         {
-            var builder = new ArrayBuilder<char>(values.Length);
+            var builder = new FlagSet.Builder(values.Length);
             foreach (var value in values)
             {
                 if (value.IsNotWildcard)
                 {
-                    builder.AddAsSortedSet(value);
+                    builder.Add(value);
                 }
             }
 
-            return FlagSet.CreateUsingOwnedBuffer(builder.MakeOrExtractArray(extract: true));
+            return builder.MoveToFlagSet();
         }
     }
 

--- a/WeCantSpell.Hunspell/FlagSet.cs
+++ b/WeCantSpell.Hunspell/FlagSet.cs
@@ -255,37 +255,6 @@ public readonly struct FlagSet : IReadOnlyList<FlagValue>, IEquatable<FlagSet>
         }
     }
 
-    private static bool SortedContains(ReadOnlySpan<char> sorted, char value)
-    {
-        return sorted.Length switch
-        {
-            0 => false,
-            1 => sorted[0] == value,
-            2 => sorted[0] == value || sorted[1] == value,
-            3 => sorted[0] == value || sorted[1] == value || sorted[2] == value,
-            <= 8 => checkIterative(sorted, value),
-            _ => sorted.BinarySearch(value) >= 0
-        };
-
-        static bool checkIterative(ReadOnlySpan<char> searchSpace, char target)
-        {
-            foreach (var value in searchSpace)
-            {
-                if (value == target)
-                {
-                    return true;
-                }
-
-                if (value > target)
-                {
-                    break;
-                }
-            }
-
-            return false;
-        }
-    }
-
 #endif
 
     private FlagSet(FlagValue value) : this((char)value)
@@ -419,7 +388,7 @@ public readonly struct FlagSet : IReadOnlyList<FlagValue>, IEquatable<FlagSet>
                 1 => _values[0] == value,
                 2 => _values[0] == value || _values[1] == value,
                 3 => _values[0] == value || _values[1] == value || _values[2] == value,
-                _ => SortedContains(_values, value),
+                _ => MemoryEx.SortedContains(_values, value),
             };
     }
 
@@ -438,7 +407,7 @@ public readonly struct FlagSet : IReadOnlyList<FlagValue>, IEquatable<FlagSet>
                 1 => _values[0] != value,
                 2 => _values[0] != value && _values[1] != value,
                 3 => _values[0] != value && _values[1] != value && _values[2] != value,
-                _ => !SortedContains(_values, value),
+                _ => !MemoryEx.SortedContains(_values, value),
             };
     }
 
@@ -537,12 +506,12 @@ public readonly struct FlagSet : IReadOnlyList<FlagValue>, IEquatable<FlagSet>
         {
             return other.Length == 1
                 ? _values[0] == other[0]
-                : SortedContains(other, _values[0]);
+                : MemoryEx.SortedContains(other, _values[0]);
         }
 
         var values = _values.AsSpan();
         return other.Length == 1
-            ? SortedContains(values, other[0])
+            ? MemoryEx.SortedContains(values, other[0])
             : SortedInterectionTest(values, other);
     }
 

--- a/WeCantSpell.Hunspell/FlagSet.cs
+++ b/WeCantSpell.Hunspell/FlagSet.cs
@@ -323,26 +323,13 @@ public readonly struct FlagSet : IReadOnlyList<FlagValue>, IEquatable<FlagSet>
             return string.Empty;
         }
 
-        if (isAllAscii(_values!))
+        if (_values!.All(static v => v < 128))
         {
             return _values!;
         }
         else
         {
             return string.Join(",", _values!.Select(static v => ((int)v).ToString(CultureInfo.InvariantCulture.NumberFormat)));
-        }
-
-        static bool isAllAscii(string value)
-        {
-            for (var i = 0; i < value.Length; i++)
-            {
-                if (value[i] >= 128)
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
     }
 

--- a/WeCantSpell.Hunspell/FlagSet.cs
+++ b/WeCantSpell.Hunspell/FlagSet.cs
@@ -171,7 +171,7 @@ public readonly struct FlagSet : IReadOnlyList<FlagValue>, IEquatable<FlagSet>
 
 #if !HAS_SEARCHVALUES
 
-    private static bool SortedInterectionTest(ReadOnlySpan<char> aSet, ReadOnlySpan<char> bSet)
+    private static bool SortedIntersectionTest(ReadOnlySpan<char> aSet, ReadOnlySpan<char> bSet)
     {
 
 #if DEBUG
@@ -525,7 +525,7 @@ public readonly struct FlagSet : IReadOnlyList<FlagValue>, IEquatable<FlagSet>
                 : (
                     _values!.Length == 1
                         ? other.Contains(_values[0])
-                        : SortedInterectionTest(other._values.AsSpan(), _values.AsSpan())
+                        : SortedIntersectionTest(other._values.AsSpan(), _values.AsSpan())
                 )
             );
     }
@@ -542,7 +542,7 @@ public readonly struct FlagSet : IReadOnlyList<FlagValue>, IEquatable<FlagSet>
                 : (
                     _values!.Length == 1
                         ? other.DoesNotContain(_values[0])
-                        : !SortedInterectionTest(other._values.AsSpan(), _values.AsSpan())
+                        : !SortedIntersectionTest(other._values.AsSpan(), _values.AsSpan())
                 )
             );
     }
@@ -564,7 +564,7 @@ public readonly struct FlagSet : IReadOnlyList<FlagValue>, IEquatable<FlagSet>
             (
                 _values!.Length == 1
                 ? MemoryEx.SortedLargeSearchSpaceContains(other, _values[0])
-                : SortedInterectionTest(_values.AsSpan(), other)
+                : SortedIntersectionTest(_values.AsSpan(), other)
             );
     }
 

--- a/WeCantSpell.Hunspell/Infrastructure/ArrayBuilder.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/ArrayBuilder.cs
@@ -70,7 +70,13 @@ sealed class ArrayBuilder<T> : IList<T>
 
     public void CopyTo(T[] array, int arrayIndex) => Array.Copy(_values, 0, array, arrayIndex, _count);
 
-    public IEnumerator<T> GetEnumerator() => _values.AsEnumerable().GetEnumerator();
+    public IEnumerator<T> GetEnumerator()
+    {
+        for (var i = 0; i < _count; i++)
+        {
+            yield return _values[i];
+        }
+    }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/WeCantSpell.Hunspell/Infrastructure/ArrayBuilder.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/ArrayBuilder.cs
@@ -15,7 +15,7 @@ sealed class ArrayBuilder<T> : IList<T>
     internal ArrayBuilder(T[] values)
     {
         _values = values;
-        Count = values.Length;
+        _count = values.Length;
     }
 
     public ArrayBuilder(int initialCapacity)
@@ -30,8 +30,9 @@ sealed class ArrayBuilder<T> : IList<T>
     }
 
     private T[] _values;
+    private int _count;
 
-    public int Count { get; private set; } = 0;
+    public int Count => _count;
 
     public int Capacity => _values.Length;
 
@@ -39,7 +40,7 @@ sealed class ArrayBuilder<T> : IList<T>
 
     public void Clear()
     {
-        Count = 0;
+        _count = 0;
     }
 
     public T this[int index]
@@ -91,7 +92,7 @@ sealed class ArrayBuilder<T> : IList<T>
             EnsureCapacityAtLeast(Count + 1);
         }
 
-        _values[Count++] = value;
+        _values[_count++] = value;
     }
 
     public void AddRange(IEnumerable<T> values)
@@ -119,7 +120,7 @@ sealed class ArrayBuilder<T> : IList<T>
         var futureSize = Count + values.Count;
         EnsureCapacityAtLeast(futureSize);
         values.CopyTo(_values, Count);
-        Count = futureSize;
+        _count = futureSize;
     }
 
     public void AddRange(T[] values)
@@ -133,7 +134,7 @@ sealed class ArrayBuilder<T> : IList<T>
         var futureSize = Count + values.Length;
         EnsureCapacityAtLeast(futureSize);
         values.CopyTo(_values, Count);
-        Count = futureSize;
+        _count = futureSize;
     }
 
     public void AddRange(ReadOnlySpan<T> values)
@@ -141,7 +142,7 @@ sealed class ArrayBuilder<T> : IList<T>
         var futureSize = Count + values.Length;
         EnsureCapacityAtLeast(futureSize);
         values.CopyTo(_values.AsSpan());
-        Count = futureSize;
+        _count = futureSize;
     }
 
     public void GrowToCapacity(int requiredLength)
@@ -230,7 +231,7 @@ sealed class ArrayBuilder<T> : IList<T>
 
         _values[insertionIndex] = value;
 
-        Count++;
+        _count++;
     }
 
     public void RemoveAt(int index)
@@ -254,7 +255,7 @@ sealed class ArrayBuilder<T> : IList<T>
 
             _values[newSize] = default!;
 
-            Count = newSize;
+            _count = newSize;
         }
     }
 
@@ -308,6 +309,8 @@ sealed class ArrayBuilder<T> : IList<T>
     public T[] MakeOrExtractArray(bool extract) => extract ? Extract() : MakeArray();
 
     internal int BinarySearch(int startIndex, int count, T value) => Array.BinarySearch(_values, startIndex, count, value);
+
+    internal Span<T> AsSpan() => _values.AsSpan(0, _count);
 
     private int CalculateBestCapacity(int minCapacity) => Math.Max(CalculateNextCapacity(), minCapacity);
 

--- a/WeCantSpell.Hunspell/Infrastructure/ArrayBuilder.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/ArrayBuilder.cs
@@ -202,6 +202,12 @@ sealed class ArrayBuilder<T> : IList<T>
 
     public void AddAsSortedSet(IEnumerable<T> values)
     {
+        var expectedCount = values.GetNonEnumeratedCountOrDefault();
+        if (expectedCount > 0)
+        {
+            EnsureCapacityAtLeast(_count + expectedCount);
+        }
+
         AddRange(values);
         Array.Sort(_values, 0, _count);
         RemoveAdjacentDuplicates();

--- a/WeCantSpell.Hunspell/Infrastructure/CollectionsEx.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/CollectionsEx.cs
@@ -105,4 +105,11 @@ static class CollectionsEx
         allowDestructive && builder.Capacity == builder.Count ? builder.MoveToImmutable() : builder.ToImmutable();
 
     public static string BuildString(this ArrayBuilder<char> builder) => builder.AsSpan().ToString();
+
+    public static string BuildStringAndReturn(ArrayBuilder<char> builder)
+    {
+        var result = builder.BuildString();
+        ArrayBuilder<char>.Pool.Return(builder);
+        return result;
+    }
 }

--- a/WeCantSpell.Hunspell/Infrastructure/CollectionsEx.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/CollectionsEx.cs
@@ -15,8 +15,9 @@ static class CollectionsEx
 
     public static int GetNonEnumeratedCountOrDefault<T>(this IEnumerable<T> enumerable) => enumerable switch
     {
-        ICollection<T> collectionGeneric => collectionGeneric.Count,
-        ICollection collectionOld => collectionOld.Count,
+        ICollection<T> c => c.Count,
+        ICollection c => c.Count,
+        IReadOnlyCollection<T> c => c.Count,
         _ => 0
     };
 
@@ -86,11 +87,6 @@ static class CollectionsEx
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool Any<T>(this List<T> list) => list.Count != 0;
 
-    public static void RemoveLast<T>(this List<T> list)
-    {
-        list.RemoveAt(list.Count - 1);
-    }
-
 #if NO_SPAN_CONTAINS
 
     public static bool Contains<T>(this T[] values, T value) where T : IEquatable<T> => Array.IndexOf(values, value) >= 0;
@@ -103,13 +99,4 @@ static class CollectionsEx
 
     public static ImmutableArray<T> ToImmutable<T>(this ImmutableArray<T>.Builder builder, bool allowDestructive) =>
         allowDestructive && builder.Capacity == builder.Count ? builder.MoveToImmutable() : builder.ToImmutable();
-
-    public static string BuildString(this ArrayBuilder<char> builder) => builder.AsSpan().ToString();
-
-    public static string BuildStringAndReturn(ArrayBuilder<char> builder)
-    {
-        var result = builder.BuildString();
-        ArrayBuilder<char>.Pool.Return(builder);
-        return result;
-    }
 }

--- a/WeCantSpell.Hunspell/Infrastructure/CollectionsEx.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/CollectionsEx.cs
@@ -104,4 +104,5 @@ static class CollectionsEx
     public static ImmutableArray<T> ToImmutable<T>(this ImmutableArray<T>.Builder builder, bool allowDestructive) =>
         allowDestructive && builder.Capacity == builder.Count ? builder.MoveToImmutable() : builder.ToImmutable();
 
+    public static string BuildString(this ArrayBuilder<char> builder) => builder.AsSpan().ToString();
 }

--- a/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
@@ -17,12 +17,6 @@ static class MemoryEx
         return result >= 0 ? result + startIndex : result;
     }
 
-    public static int IndexOf(this Span<char> @this, ReadOnlySpan<char> value, int startIndex)
-    {
-        var result = @this.Slice(startIndex).IndexOf(value);
-        return result >= 0 ? result + startIndex : result;
-    }
-
     public static bool SortedContains(ReadOnlySpan<char> sorted, char value)
     {
         return sorted.Length switch

--- a/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
@@ -23,6 +23,37 @@ static class MemoryEx
         return result >= 0 ? result + startIndex : result;
     }
 
+    public static bool SortedContains(ReadOnlySpan<char> sorted, char value)
+    {
+        return sorted.Length switch
+        {
+            0 => false,
+            1 => sorted[0] == value,
+            2 => sorted[0] == value || sorted[1] == value,
+            3 => sorted[0] == value || sorted[1] == value || sorted[2] == value,
+            <= 8 => checkIterative(sorted, value),
+            _ => sorted.BinarySearch(value) >= 0
+        };
+
+        static bool checkIterative(ReadOnlySpan<char> searchSpace, char target)
+        {
+            foreach (var value in searchSpace)
+            {
+                if (value == target)
+                {
+                    return true;
+                }
+
+                if (value > target)
+                {
+                    break;
+                }
+            }
+
+            return false;
+        }
+    }
+
     public static ReadOnlySpan<char> Limit(this ReadOnlySpan<char> @this, int maxLength) =>
         @this.Length > maxLength ? @this.Slice(0, maxLength) : @this;
 

--- a/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
@@ -19,12 +19,13 @@ static class MemoryEx
 
     public static bool SortedLargeSearchSpaceContains(ReadOnlySpan<char> sorted, char value)
     {
-        return (value >= sorted[0] && value <= sorted[sorted.Length - 1])
+        return
+            (value <= sorted[sorted.Length - 1])
             &&
             (
-                sorted.Length <= 8
+                sorted.Length < 8
                 ? checkIterative(sorted, value)
-                : sorted.BinarySearch(value) >= 0
+                : (value >= sorted[0] && sorted.BinarySearch(value) >= 0)
             );
 
         static bool checkIterative(ReadOnlySpan<char> searchSpace, char target)

--- a/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
@@ -17,17 +17,15 @@ static class MemoryEx
         return result >= 0 ? result + startIndex : result;
     }
 
-    public static bool SortedContains(ReadOnlySpan<char> sorted, char value)
+    public static bool SortedLargeSearchSpaceContains(ReadOnlySpan<char> sorted, char value)
     {
-        return sorted.Length switch
-        {
-            0 => false,
-            1 => sorted[0] == value,
-            2 => sorted[0] == value || sorted[1] == value,
-            3 => sorted[0] == value || sorted[1] == value || sorted[2] == value,
-            <= 8 => checkIterative(sorted, value),
-            _ => sorted.BinarySearch(value) >= 0
-        };
+        return (value >= sorted[0] && value <= sorted[sorted.Length - 1])
+            &&
+            (
+                sorted.Length <= 8
+                ? checkIterative(sorted, value)
+                : sorted.BinarySearch(value) >= 0
+            );
 
         static bool checkIterative(ReadOnlySpan<char> searchSpace, char target)
         {

--- a/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/MemoryEx.cs
@@ -145,6 +145,22 @@ static class MemoryEx
 
 #endif
 
+    public static bool CheckSortedWithoutDuplicates(this ReadOnlySpan<char> span)
+    {
+        if (span.Length > 1)
+        {
+            for (var i = 1; i < span.Length; i++)
+            {
+                if (span[i - 1] >= span[i])
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
     public static void RemoveAll<T>(ref Span<T> span, T value) where T : notnull, IEquatable<T>
     {
         var readIndex = span.IndexOf(value);

--- a/WeCantSpell.Hunspell/Infrastructure/StringBuilderSpan.cs
+++ b/WeCantSpell.Hunspell/Infrastructure/StringBuilderSpan.cs
@@ -202,6 +202,14 @@ ref struct StringBuilderSpan
         _length++;
     }
 
+    public void AppendIfNotNull(char value)
+    {
+        if (value != default)
+        {
+            Append(value);
+        }
+    }
+
     public void AppendLower(scoped ReadOnlySpan<char> value, CultureInfo cultureInfo)
     {
         var space = AppendSpaceForImmediateWrite(value.Length);
@@ -455,6 +463,16 @@ ref struct StringBuilderSpan
         }
 
         _length -= count;
+    }
+
+    public void RemoveAll(char value)
+    {
+        var index = _bufferSpan.Slice(0, _length).IndexOf(value);
+        while (index >= 0 && index < _length)
+        {
+            RemoveAt(index);
+            index = ((ReadOnlySpan<char>)_bufferSpan.Slice(0, _length)).IndexOf(value, index);
+        }
     }
 
     public void Insert(int index, char value)

--- a/WeCantSpell.Hunspell/SpecialFlags.cs
+++ b/WeCantSpell.Hunspell/SpecialFlags.cs
@@ -24,7 +24,7 @@ public static class SpecialFlags
 
     public static FlagValue LetterPercent { get; } = new FlagValue('%');
 
-    public static FlagSet SetFGH { get; } = FlagSet.CreateUsingOwnedBuffer([LetterF, LetterG, LetterH]);
+    public static FlagSet SetFGH { get; } = FlagSet.Create(LetterF, LetterG, LetterH);
 
-    public static FlagSet SetXPercent { get; } = FlagSet.CreateUsingOwnedBuffer([LetterXLower, LetterPercent]);
+    public static FlagSet SetXPercent { get; } = FlagSet.Create(LetterXLower, LetterPercent);
 }

--- a/WeCantSpell.Hunspell/WordList.Builder.cs
+++ b/WeCantSpell.Hunspell/WordList.Builder.cs
@@ -56,7 +56,7 @@ public partial class WordList
 
         public WordList ToImmutable(bool allowDestructive)
         {
-            var result = new WordList(Affix, nGramRestrictedFlags: FlagSet.CreateUsingOwnedBuffer(
+            var result = new WordList(Affix, nGramRestrictedFlags: FlagSet.Create(
             [
                 Affix.ForbiddenWord,
                 Affix.NoSuggest,


### PR DESCRIPTION
For immutable types that are backed by `char[]`, this replaces them with `string`. It also cleans a bunch of other related junk up too which will hopefully reduce assembly size.