### PR TITLE
fix reading Map command with inline comment

### DIFF
--- a/WeCantSpell.Hunspell.Tests/AffixReaderTests.cs
+++ b/WeCantSpell.Hunspell.Tests/AffixReaderTests.cs
@@ -19,6 +19,28 @@ public class AffixReaderTests
         Helpers.EnsureEncodingsReady();
     }
 
+    public class ReadFile : AffixReaderTests
+    {
+        [Fact]
+        public void can_read_map_with_comments()
+        {
+            var fileContents =
+            """
+            MAP 3
+            MAP (NJ)Ǌ
+            MAP (ng)ŋ #"Latin small letter eng"
+            MAP (NG)Ŋ #"Latin capital letter eng"
+            """;
+
+            var affix = AffixReader.ReadFromString(fileContents);
+
+            affix.RelatedCharacterMap.Count.ShouldBe(3);
+            affix.RelatedCharacterMap[0].ShouldBe(["NJ", "Ǌ"]);
+            affix.RelatedCharacterMap[1].ShouldBe(["ng", "ŋ"]);
+            affix.RelatedCharacterMap[2].ShouldBe(["NG", "Ŋ"]);
+        }
+    }
+
     public class ReadFileAsync : AffixReaderTests
     {
         [Fact]

--- a/WeCantSpell.Hunspell/AffixReader.cs
+++ b/WeCantSpell.Hunspell/AffixReader.cs
@@ -630,6 +630,9 @@ public sealed partial class AffixReader
 
         for (var k = 0; k < parameterText.Length; k++)
         {
+            if (parameterText[k] == '#')
+                break;
+
             var chb = k;
             var che = k + 1;
             if (parameterText[k] == '(' && parameterText.IndexOf(')', k) is int parpos and >= 0)


### PR DESCRIPTION
certain AFF files like the latest Danish one (which can be downloaded from https://stavekontrolden.dk/?dictionaries=1) have inlined comments in commands. This looks like following:

> MAP (NJ)Ǌ
> MAP (ng)ŋ #"Latin small letter eng"
> MAP (NG)Ŋ #"Latin capital letter eng"
> MAP oóòôöõōŏǒőȍȏǫǭ #Næstsidste: "Latin small letter o with ogonek"
> MAP OÓÒÔÖÕǑŌŎŐȌȎǪǬƆ #Tredjesidste: "Latin capital letter O with ogonek". Sidste: "Capital letter open O"
> MAP (oe)œ
> MAP (OE)Œ

this seems to be no problem for parsing other commands, but for MAP it caused the Map array to grow too much, which results in  suggestions lookup taking too much time and thus returning empty suggestions most of the time